### PR TITLE
Fix sebastian/diff minimum version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/php-collective/dto",
     "require": {
         "php": "^8.2",
-        "sebastian/diff": "^5.0 || ^6.0 || ^7.0",
+        "sebastian/diff": "^6.0 || ^7.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Remove `^5.0` from sebastian/diff version constraint since PHPUnit 11+ requires `^6.0`, making 5.x impossible to install

Fixes the prefer-lowest CI validation failure.