### PR TITLE
Add CLI and ConsoleIo tests, improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,54 @@ Dto::setCollectionFactory(fn($items) => collect($items));
 The library supports multiple configuration formats:
 
 - **XML** (default) - with XSD validation and IDE autocomplete
-- **YAML** - requires `symfony/yaml` (included via Twig)
+- **YAML** - requires PHP YAML extension (`pecl install yaml`)
 - **NEON** - requires `nette/neon`
 - **PHP** - native PHP arrays, best IDE support for complex configs
 
 ### YAML Example
 
 ```yaml
+# config/dto.yml
 Car:
     fields:
         color: string
         isNew: bool
+        distanceTravelled:
+            type: int
+            defaultValue: 0
+        owner:
+            type: Owner
+            required: true
+        parts:
+            type: Part[]
+            collection: true
+            singular: part
+
+Owner:
+    fields:
+        name: string
+        birthYear: int
+
+ImmutableConfig:
+    immutable: true
+    fields:
+        apiKey: string
+        timeout:
+            type: int
+            defaultValue: 30
+```
+
+### NEON Example
+
+```neon
+# config/dto.neon
+Car:
+    fields:
+        color: string
+        isNew: bool
+        distanceTravelled:
+            type: int
+            defaultValue: 0
         owner:
             type: Owner
             required: true
@@ -280,18 +317,7 @@ Car:
 Owner:
     fields:
         name: string
-```
-
-### NEON Example
-
-```neon
-Car:
-    fields:
-        color: string
-        isNew: bool
-        owner:
-            type: Owner
-            required: true
+        birthYear: int
 ```
 
 ### PHP Example

--- a/tests/Cli/CliTest.php
+++ b/tests/Cli/CliTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Cli;
+
+use PHPUnit\Framework\TestCase;
+
+class CliTest extends TestCase
+{
+    protected string $binPath;
+    protected string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->binPath = dirname(__DIR__, 2) . '/bin/dto';
+        $this->tempDir = sys_get_temp_dir() . '/dto_cli_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        mkdir($this->tempDir . '/config', 0777, true);
+        mkdir($this->tempDir . '/src', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    protected function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Exit code when changes were made (in verbose/dry-run mode).
+     */
+    protected const CODE_CHANGES = 2;
+
+    protected function runCli(string $args = ''): array
+    {
+        $cmd = sprintf('php %s %s 2>&1', escapeshellarg($this->binPath), $args);
+        exec($cmd, $output, $exitCode);
+
+        return [
+            'output' => implode("\n", $output),
+            'exitCode' => $exitCode,
+        ];
+    }
+
+    public function testHelp(): void
+    {
+        $result = $this->runCli('--help');
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertStringContainsString('DTO Generator', $result['output']);
+        $this->assertStringContainsString('--config-path', $result['output']);
+        $this->assertStringContainsString('--src-path', $result['output']);
+        $this->assertStringContainsString('--namespace', $result['output']);
+        $this->assertStringContainsString('--dry-run', $result['output']);
+    }
+
+    public function testHelpShort(): void
+    {
+        $result = $this->runCli('-h');
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertStringContainsString('DTO Generator', $result['output']);
+    }
+
+    public function testInvalidConfigPath(): void
+    {
+        $result = $this->runCli('generate --config-path=/nonexistent/path');
+
+        $this->assertNotSame(0, $result['exitCode']);
+        $this->assertStringContainsString('does not exist', $result['output']);
+    }
+
+    public function testUnknownCommand(): void
+    {
+        $result = $this->runCli('unknown');
+
+        $this->assertNotSame(0, $result['exitCode']);
+        $this->assertStringContainsString('Unknown command', $result['output']);
+    }
+
+    public function testGenerateWithXmlConfig(): void
+    {
+        // Create a simple XML config
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="User">
+        <field name="id" type="int"/>
+        <field name="name" type="string"/>
+    </dto>
+</dtos>
+XML;
+        file_put_contents($this->tempDir . '/config/dto.xml', $xml);
+
+        $result = $this->runCli(sprintf(
+            'generate --config-path=%s/config --src-path=%s/src --namespace=TestApp',
+            escapeshellarg($this->tempDir),
+            escapeshellarg($this->tempDir),
+        ));
+
+        $this->assertSame(0, $result['exitCode'], 'CLI should exit with 0. Output: ' . $result['output']);
+        $this->assertFileExists($this->tempDir . '/src/Dto/UserDto.php');
+
+        $content = file_get_contents($this->tempDir . '/src/Dto/UserDto.php');
+        $this->assertStringContainsString('namespace TestApp\Dto;', $content);
+        $this->assertStringContainsString('class UserDto', $content);
+    }
+
+    public function testGenerateWithNeonConfig(): void
+    {
+        // Create a simple NEON config
+        $neon = <<<'NEON'
+User:
+    fields:
+        id: int
+        name: string
+NEON;
+        file_put_contents($this->tempDir . '/config/dto.neon', $neon);
+
+        $result = $this->runCli(sprintf(
+            'generate --config-path=%s/config --src-path=%s/src --namespace=TestApp --format=neon',
+            escapeshellarg($this->tempDir),
+            escapeshellarg($this->tempDir),
+        ));
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertFileExists($this->tempDir . '/src/Dto/UserDto.php');
+    }
+
+    public function testGenerateDryRun(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="User">
+        <field name="id" type="int"/>
+    </dto>
+</dtos>
+XML;
+        file_put_contents($this->tempDir . '/config/dto.xml', $xml);
+
+        $result = $this->runCli(sprintf(
+            'generate --config-path=%s/config --src-path=%s/src --namespace=TestApp --dry-run',
+            escapeshellarg($this->tempDir),
+            escapeshellarg($this->tempDir),
+        ));
+
+        // In dry-run mode, returns CODE_CHANGES (2) if changes would be made
+        $this->assertSame(self::CODE_CHANGES, $result['exitCode'], 'CLI should exit with 2 (changes). Output: ' . $result['output']);
+        // File should NOT be created in dry-run mode
+        $this->assertFileDoesNotExist($this->tempDir . '/src/Dto/UserDto.php');
+    }
+
+    public function testGenerateVerbose(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="User">
+        <field name="id" type="int"/>
+    </dto>
+</dtos>
+XML;
+        file_put_contents($this->tempDir . '/config/dto.xml', $xml);
+
+        $result = $this->runCli(sprintf(
+            'generate --config-path=%s/config --src-path=%s/src --namespace=TestApp --verbose',
+            escapeshellarg($this->tempDir),
+            escapeshellarg($this->tempDir),
+        ));
+
+        // In verbose mode, returns CODE_CHANGES (2) if changes were made
+        $this->assertSame(self::CODE_CHANGES, $result['exitCode'], 'CLI should exit with 2 (changes). Output: ' . $result['output']);
+        $this->assertStringContainsString('Namespace:', $result['output']);
+        $this->assertStringContainsString('Format:', $result['output']);
+    }
+
+    public function testGenerateWithPhpConfig(): void
+    {
+        // Create a simple PHP config
+        $php = <<<'PHP'
+<?php
+return [
+    'User' => [
+        'fields' => [
+            'id' => 'int',
+            'name' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $php);
+
+        $result = $this->runCli(sprintf(
+            'generate --config-path=%s/config --src-path=%s/src --namespace=TestApp --format=php',
+            escapeshellarg($this->tempDir),
+            escapeshellarg($this->tempDir),
+        ));
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertFileExists($this->tempDir . '/src/Dto/UserDto.php');
+    }
+
+    public function testFormatAutoDetection(): void
+    {
+        // Create NEON config and let it auto-detect
+        $neon = <<<'NEON'
+User:
+    fields:
+        id: int
+NEON;
+        file_put_contents($this->tempDir . '/config/dto.neon', $neon);
+
+        $result = $this->runCli(sprintf(
+            'generate --config-path=%s/config --src-path=%s/src --namespace=TestApp --verbose',
+            escapeshellarg($this->tempDir),
+            escapeshellarg($this->tempDir),
+        ));
+
+        // In verbose mode, returns CODE_CHANGES (2) if changes were made
+        $this->assertSame(self::CODE_CHANGES, $result['exitCode']);
+        $this->assertStringContainsString('Format: neon', $result['output']);
+    }
+}

--- a/tests/Generator/ConsoleIoTest.php
+++ b/tests/Generator/ConsoleIoTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\IoInterface;
+use PHPUnit\Framework\TestCase;
+
+class ConsoleIoTest extends TestCase
+{
+    /**
+     * @var resource
+     */
+    protected $stdout;
+
+    /**
+     * @var resource
+     */
+    protected $stderr;
+
+    protected function setUp(): void
+    {
+        $this->stdout = fopen('php://memory', 'r+');
+        $this->stderr = fopen('php://memory', 'r+');
+    }
+
+    protected function tearDown(): void
+    {
+        fclose($this->stdout);
+        fclose($this->stderr);
+    }
+
+    protected function getStdoutOutput(): string
+    {
+        rewind($this->stdout);
+
+        return stream_get_contents($this->stdout);
+    }
+
+    protected function getStderrOutput(): string
+    {
+        rewind($this->stderr);
+
+        return stream_get_contents($this->stderr);
+    }
+
+    public function testOutNormalLevel(): void
+    {
+        $io = new ConsoleIo(IoInterface::NORMAL, $this->stdout, $this->stderr);
+        $io->out('Test message');
+
+        $this->assertSame("Test message\n", $this->getStdoutOutput());
+    }
+
+    public function testOutQuietLevel(): void
+    {
+        $io = new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stderr);
+        $io->out('Test message', 1, IoInterface::NORMAL);
+
+        $this->assertSame('', $this->getStdoutOutput());
+    }
+
+    public function testOutVerboseLevel(): void
+    {
+        $io = new ConsoleIo(IoInterface::VERBOSE, $this->stdout, $this->stderr);
+        $io->out('Test message', 1, IoInterface::VERBOSE);
+
+        $this->assertSame("Test message\n", $this->getStdoutOutput());
+    }
+
+    public function testVerboseOnlyShowsWhenVerbose(): void
+    {
+        $io = new ConsoleIo(IoInterface::NORMAL, $this->stdout, $this->stderr);
+        $io->verbose('Verbose message');
+
+        $this->assertSame('', $this->getStdoutOutput());
+
+        // Reset streams
+        fclose($this->stdout);
+        $this->stdout = fopen('php://memory', 'r+');
+
+        $io = new ConsoleIo(IoInterface::VERBOSE, $this->stdout, $this->stderr);
+        $io->verbose('Verbose message');
+
+        $this->assertSame("Verbose message\n", $this->getStdoutOutput());
+    }
+
+    public function testQuietAlwaysShows(): void
+    {
+        $io = new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stderr);
+        $io->quiet('Quiet message');
+
+        $this->assertSame("Quiet message\n", $this->getStdoutOutput());
+    }
+
+    public function testMultipleNewlines(): void
+    {
+        $io = new ConsoleIo(IoInterface::NORMAL, $this->stdout, $this->stderr);
+        $io->out('Test', 3);
+
+        $this->assertSame("Test\n\n\n", $this->getStdoutOutput());
+    }
+
+    public function testSuccessNormalLevel(): void
+    {
+        $io = new ConsoleIo(IoInterface::NORMAL, $this->stdout, $this->stderr);
+        $io->success('Success message');
+
+        // Output may or may not have color codes depending on terminal
+        $this->assertStringContainsString('Success message', $this->getStdoutOutput());
+    }
+
+    public function testSuccessQuietLevel(): void
+    {
+        $io = new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stderr);
+        $io->success('Success message', 1, IoInterface::NORMAL);
+
+        $this->assertSame('', $this->getStdoutOutput());
+    }
+
+    public function testOutWithArray(): void
+    {
+        $io = new ConsoleIo(IoInterface::NORMAL, $this->stdout, $this->stderr);
+        $io->verbose(['Line 1', 'Line 2']);
+
+        $this->assertSame('', $this->getStdoutOutput());
+
+        // Reset streams
+        fclose($this->stdout);
+        $this->stdout = fopen('php://memory', 'r+');
+
+        $io = new ConsoleIo(IoInterface::VERBOSE, $this->stdout, $this->stderr);
+        $io->verbose(['Line 1', 'Line 2']);
+
+        $this->assertSame("Line 1\nLine 2\n", $this->getStdoutOutput());
+    }
+
+    public function testErrorGoesToStderr(): void
+    {
+        $io = new ConsoleIo(IoInterface::NORMAL, $this->stdout, $this->stderr);
+        $io->error('Error message');
+
+        $this->assertSame('', $this->getStdoutOutput());
+        $this->assertStringContainsString('Error message', $this->getStderrOutput());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `CliTest` with comprehensive tests for all CLI features:
  - Help output (`--help`, `-h`)
  - Invalid config path handling
  - Unknown command handling
  - XML, NEON, and PHP config format generation
  - Dry-run mode
  - Verbose mode
  - Auto-format detection
- Add `ConsoleIoTest` with proper stream injection for testing
- Make `ConsoleIo` testable by accepting configurable stdout/stderr streams
- Update README with enhanced YAML/NEON configuration examples showing:
  - Default values
  - Required fields
  - Collections
  - Immutable DTOs
- Fix README to correctly state YAML requires PHP YAML extension (not symfony/yaml)

## Test plan

- [x] All 137 tests pass
- [x] CLI tests cover help, generate, error handling, and all config formats
- [x] ConsoleIo tests verify output routing and verbosity levels