### PR TITLE
Add PHP 8.0+ union type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ $touched = $carDto->touchedToArray();   // Only fields that were set
 
 **Scalar types:** `int`, `float`, `string`, `bool`, `callable`, `resource`, `iterable`, `object`, `mixed`
 
+**Union types (PHP 8.0+):** `int|string`, `int|float|string`, etc.
+
 **Array types:** `array`, `string[]`, `int[]`, etc.
 
 **Objects:**
@@ -143,6 +145,39 @@ $touched = $carDto->touchedToArray();   // Only fields that were set
 - `collection="true"` - as `\ArrayObject` (recommended)
 - `collectionType="array"` - as plain array
 - `collectionType="\Custom\Collection"` - custom collection class
+
+### Union Types
+
+PHP 8.0+ union types are fully supported:
+
+```xml
+<dto name="Product">
+    <field name="id" type="int|string" required="true"/>
+    <field name="price" type="int|float"/>
+</dto>
+```
+
+```yaml
+Product:
+    fields:
+        id:
+            type: int|string
+            required: true
+        price: int|float
+```
+
+Generated PHP with proper type hints:
+
+```php
+class ProductDto extends AbstractDto
+{
+    public function setId(int|string $id): self { ... }
+    public function getId(): int|string { ... }
+
+    public function setPrice(int|float|null $price = null): self { ... }
+    public function getPrice(): int|float|null { ... }
+}
+```
 
 ### Immutable DTOs
 

--- a/docs/ConfigBuilder.md
+++ b/docs/ConfigBuilder.md
@@ -95,6 +95,17 @@ Field::class('money', \Money\Money::class)->factory('fromArray')
 Field::enum('status', \App\Enum\OrderStatus::class)
 ```
 
+### Union Types (PHP 8.0+)
+
+```php
+Field::union('id', 'int', 'string')              // int|string
+Field::union('value', 'int', 'float', 'string')  // int|float|string
+Field::union('id', 'int', 'string')->required()  // Required union type
+
+// Or using of() for explicit union strings
+Field::of('mixed', 'int|string|null')
+```
+
 ### Custom Types
 
 ```php
@@ -216,12 +227,12 @@ return Schema::create()
         Field::enum('status', \App\Enum\OrderStatus::class)->required(),
     ))
 
-    // Order item
+    // Order item with union type for flexible pricing
     ->dto(Dto::create('OrderItem')->fields(
-        Field::int('productId')->required(),
+        Field::union('productId', 'int', 'string')->required(),  // Flexible ID
         Field::string('name')->required(),
         Field::int('quantity')->required(),
-        Field::float('price')->required(),
+        Field::union('price', 'int', 'float')->required(),  // Price as int or float
     ))
 
     // Immutable event

--- a/src/Config/Field.php
+++ b/src/Config/Field.php
@@ -17,6 +17,7 @@ namespace PhpCollective\Dto\Config;
  * @method static \PhpCollective\Dto\Config\FieldBuilder class(string $name, string $className)
  * @method static \PhpCollective\Dto\Config\FieldBuilder enum(string $name, string $enumClass)
  * @method static \PhpCollective\Dto\Config\FieldBuilder mixed(string $name)
+ * @method static \PhpCollective\Dto\Config\FieldBuilder union(string $name, string ...$types)
  * @method static \PhpCollective\Dto\Config\FieldBuilder of(string $name, string $type)
  */
 class Field extends FieldBuilder

--- a/src/Config/FieldBuilder.php
+++ b/src/Config/FieldBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCollective\Dto\Config;
 
+use InvalidArgumentException;
+
 /**
  * Fluent builder for DTO field configuration.
  *
@@ -139,6 +141,23 @@ class FieldBuilder
     public static function mixed(string $name): static
     {
         return new static($name, 'mixed');
+    }
+
+    /**
+     * Create a union type field (PHP 8.0+).
+     *
+     * @example Field::union('id', 'int', 'string') // Creates 'int|string'
+     * @example Field::union('value', 'int', 'float', 'string') // Creates 'int|float|string'
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function union(string $name, string ...$types): static
+    {
+        if (count($types) < 2) {
+            throw new InvalidArgumentException('Union types require at least 2 types');
+        }
+
+        return new static($name, implode('|', $types));
     }
 
     /**

--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -526,10 +526,25 @@ class Builder
 
             if ($fields[$key]['typeHint'] && $this->config['scalarAndReturnTypes']) {
                 $fields[$key]['returnTypeHint'] = $fields[$key]['typeHint'];
+
+                // Pre-compute nullable return type hint (for getters)
+                if ($fields[$key]['nullable']) {
+                    // For union types (PHP 8.0+), use |null suffix instead of ? prefix
+                    if ($this->isUnionType($fields[$key]['typeHint'])) {
+                        $fields[$key]['nullableReturnTypeHint'] = $fields[$key]['typeHint'] . '|null';
+                    } else {
+                        $fields[$key]['nullableReturnTypeHint'] = '?' . $fields[$key]['typeHint'];
+                    }
+                }
             }
 
             if ($fields[$key]['typeHint'] && $this->config['scalarAndReturnTypes'] && $fields[$key]['nullable']) {
-                $fields[$key]['nullableTypeHint'] = '?' . $fields[$key]['typeHint'];
+                // For union types (PHP 8.0+), use |null suffix instead of ? prefix
+                if ($this->isUnionType($fields[$key]['typeHint'])) {
+                    $fields[$key]['nullableTypeHint'] = $fields[$key]['typeHint'] . '|null';
+                } else {
+                    $fields[$key]['nullableTypeHint'] = '?' . $fields[$key]['typeHint'];
+                }
             }
 
             if ($fields[$key]['collection']) {
@@ -537,6 +552,7 @@ class Builder
                     'singularTypeHint' => null,
                     'singularNullable' => false,
                     'singularReturnTypeHint' => null,
+                    'singularNullableReturnTypeHint' => null,
                 ];
                 if ($fields[$key]['singularType']) {
                     $fields[$key]['singularTypeHint'] = $this->typehint($fields[$key]['singularType']);
@@ -544,6 +560,15 @@ class Builder
 
                 if ($fields[$key]['singularTypeHint'] && $this->config['scalarAndReturnTypes']) {
                     $fields[$key]['singularReturnTypeHint'] = $fields[$key]['singularTypeHint'];
+
+                    // Pre-compute nullable singular return type hint for associative collections
+                    if ($fields[$key]['singularNullable']) {
+                        if ($this->isUnionType($fields[$key]['singularTypeHint'])) {
+                            $fields[$key]['singularNullableReturnTypeHint'] = $fields[$key]['singularTypeHint'] . '|null';
+                        } else {
+                            $fields[$key]['singularNullableReturnTypeHint'] = '?' . $fields[$key]['singularTypeHint'];
+                        }
+                    }
                 }
             }
         }
@@ -801,11 +826,12 @@ class Builder
      */
     protected function typehint(string $type): ?string
     {
-        // Unset the typehint for simple type unions
+        // Handle simple type unions (PHP 8.0+)
         if ($this->isValidSimpleType($type)) {
             $types = explode('|', $type);
             if (count($types) > 1) {
-                return null;
+                // Return union type for PHP 8.0+
+                return $type;
             }
         }
         if (in_array($type, $this->simpleTypeAdditionsForDocBlock, true)) {
@@ -816,6 +842,18 @@ class Builder
         }
 
         return $type;
+    }
+
+    /**
+     * Check if a type is a union type.
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    protected function isUnionType(string $type): bool
+    {
+        return str_contains($type, '|');
     }
 
     /**

--- a/src/Generator/TypeScriptGenerator.php
+++ b/src/Generator/TypeScriptGenerator.php
@@ -271,6 +271,29 @@ class TypeScriptGenerator
      */
     protected function mapScalarType(string $type): string
     {
+        // Handle union types (PHP 8.0+)
+        if (str_contains($type, '|')) {
+            $types = explode('|', $type);
+            $mappedTypes = array_map(fn ($t) => $this->mapSingleScalarType(trim($t)), $types);
+
+            // Deduplicate (e.g., int|float both map to number)
+            $mappedTypes = array_unique($mappedTypes);
+
+            return implode(' | ', $mappedTypes);
+        }
+
+        return $this->mapSingleScalarType($type);
+    }
+
+    /**
+     * Map a single scalar or class type.
+     *
+     * @param string $type
+     *
+     * @return string
+     */
+    protected function mapSingleScalarType(string $type): string
+    {
         // Check scalar types
         $lowerType = strtolower($type);
         if (isset(self::TYPE_MAP[$lowerType])) {

--- a/templates/element/method_get.twig
+++ b/templates/element/method_get.twig
@@ -6,7 +6,7 @@
 	 * @return {{ type }}{% if nullable %}|null{% endif %}
 
 	 */
-	public function get{{ name[:1]|upper ~ name[1:] }}(){% if returnTypeHint %}: {% if nullable %}?{% endif %}{{ returnTypeHint }}{% endif %} {
+	public function get{{ name[:1]|upper ~ name[1:] }}(){% if returnTypeHint %}: {{ nullableReturnTypeHint ?? returnTypeHint }}{% endif %} {
 {% if collection %}
 		if ($this->{{ name }} === null) {
 			return {% if collectionType == 'array' %}[]{% else %}new {{ typeHint }}([]){% endif %};
@@ -31,7 +31,7 @@
 	 * @throws \RuntimeException If value with this key is not set.
 {% endif %}
 	 */
-	public function get{{ singular[:1]|upper ~ singular[1:] }}($key){% if singularReturnTypeHint %}: {% if singularNullable %}?{% endif %}{{ singularReturnTypeHint }}{% endif %} {
+	public function get{{ singular[:1]|upper ~ singular[1:] }}($key){% if singularReturnTypeHint %}: {{ singularNullableReturnTypeHint ?? singularReturnTypeHint }}{% endif %} {
 {% if singularNullable %}
 		if (!isset($this->{{ name }}[$key])) {
 			return null;

--- a/tests/Config/BuilderTest.php
+++ b/tests/Config/BuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCollective\Dto\Test\Config;
 
 use DateTimeImmutable;
+use InvalidArgumentException;
 use PhpCollective\Dto\Config\Dto;
 use PhpCollective\Dto\Config\Field;
 use PhpCollective\Dto\Config\Schema;
@@ -134,6 +135,38 @@ class BuilderTest extends TestCase
             'type' => 'string',
             'deprecated' => 'Use newField instead',
         ], $field->toArray());
+    }
+
+    public function testFieldUnion(): void
+    {
+        $field = Field::union('id', 'int', 'string');
+
+        $this->assertSame('id', $field->getName());
+        $this->assertSame('int|string', $field->toArray());
+    }
+
+    public function testFieldUnionWithThreeTypes(): void
+    {
+        $field = Field::union('value', 'int', 'float', 'string');
+
+        $this->assertSame('int|float|string', $field->toArray());
+    }
+
+    public function testFieldUnionRequired(): void
+    {
+        $field = Field::union('id', 'int', 'string')->required();
+
+        $this->assertSame([
+            'type' => 'int|string',
+            'required' => true,
+        ], $field->toArray());
+    }
+
+    public function testFieldUnionRequiresAtLeastTwoTypes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Union types require at least 2 types');
+        Field::union('value', 'int');
     }
 
     public function testFieldFactory(): void

--- a/tests/Generator/UnionTypeTest.php
+++ b/tests/Generator/UnionTypeTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Engine\PhpEngine;
+use PhpCollective\Dto\Generator\ArrayConfig;
+use PhpCollective\Dto\Generator\Builder;
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\Generator;
+use PhpCollective\Dto\Generator\IoInterface;
+use PhpCollective\Dto\Generator\TwigRenderer;
+use PhpCollective\Dto\Generator\TypeScriptGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PHP 8.0+ union type support.
+ */
+class UnionTypeTest extends TestCase
+{
+    protected string $tempDir;
+
+    /**
+     * @var resource
+     */
+    protected $stdout;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/union_type_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        mkdir($this->tempDir . '/config', 0777, true);
+        $this->stdout = fopen('php://memory', 'r+');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+        fclose($this->stdout);
+    }
+
+    protected function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    protected function createIo(): ConsoleIo
+    {
+        return new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stdout);
+    }
+
+    public function testBuilderParsesUnionType(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'UnionTest' => [
+        'fields' => [
+            'value' => 'int|string',
+            'data' => 'int|float|string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $this->assertArrayHasKey('UnionTest', $definitions);
+        $fields = $definitions['UnionTest']['fields'];
+
+        // Type should remain as union
+        $this->assertSame('int|string', $fields['value']['type']);
+        $this->assertSame('int|float|string', $fields['data']['type']);
+
+        // TypeHint should be the union type for PHP 8.0+
+        $this->assertSame('int|string', $fields['value']['typeHint']);
+        $this->assertSame('int|float|string', $fields['data']['typeHint']);
+
+        // ReturnTypeHint should also be the union type
+        $this->assertSame('int|string', $fields['value']['returnTypeHint']);
+        $this->assertSame('int|float|string', $fields['data']['returnTypeHint']);
+    }
+
+    public function testBuilderNullableUnionType(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'NullableUnion' => [
+        'fields' => [
+            'value' => [
+                'type' => 'int|string',
+            ],
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $field = $definitions['NullableUnion']['fields']['value'];
+
+        // Nullable fields should use |null suffix instead of ? prefix
+        $this->assertTrue($field['nullable']);
+        $this->assertSame('int|string|null', $field['nullableTypeHint']);
+        $this->assertSame('int|string|null', $field['nullableReturnTypeHint']);
+    }
+
+    public function testBuilderRequiredUnionType(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'RequiredUnion' => [
+        'fields' => [
+            'value' => [
+                'type' => 'int|string',
+                'required' => true,
+            ],
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $field = $definitions['RequiredUnion']['fields']['value'];
+
+        // Required fields are not nullable
+        $this->assertFalse($field['nullable']);
+        $this->assertSame('int|string', $field['typeHint']);
+        $this->assertNull($field['nullableTypeHint']);
+    }
+
+    public function testGeneratorCreatesUnionTypeHints(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'UnionDto' => [
+        'fields' => [
+            'identifier' => [
+                'type' => 'int|string',
+                'required' => true,
+            ],
+            'optionalValue' => 'int|float',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'TestApp']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+        $renderer = new TwigRenderer(null, $config);
+
+        $generator = new Generator($builder, $renderer, $this->createIo(), $config);
+        $generator->generate($this->tempDir . '/config/', $this->tempDir . '/src/');
+
+        $generatedFile = $this->tempDir . '/src/Dto/UnionDtoDto.php';
+        $this->assertFileExists($generatedFile);
+
+        $content = file_get_contents($generatedFile);
+
+        // Setter for required union type - no nullable
+        $this->assertStringContainsString('public function setIdentifier(int|string $identifier)', $content);
+
+        // Getter for required union type - returns the type directly
+        $this->assertStringContainsString('public function getIdentifier(): int|string', $content);
+
+        // Setter for optional union type - uses |null suffix with default = null
+        $this->assertStringContainsString('public function setOptionalValue(int|float|null $optionalValue = null)', $content);
+
+        // Getter for optional union type - uses |null suffix
+        $this->assertStringContainsString('public function getOptionalValue(): int|float|null', $content);
+    }
+
+    public function testGeneratedDtoWithUnionTypesIsValid(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'ValidUnion' => [
+        'fields' => [
+            'id' => [
+                'type' => 'int|string',
+                'required' => true,
+            ],
+            'score' => 'int|float',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'TestApp']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+        $renderer = new TwigRenderer(null, $config);
+
+        $generator = new Generator($builder, $renderer, $this->createIo(), $config);
+        $generator->generate($this->tempDir . '/config/', $this->tempDir . '/src/');
+
+        $generatedFile = $this->tempDir . '/src/Dto/ValidUnionDto.php';
+        $this->assertFileExists($generatedFile);
+
+        // Verify the generated PHP is syntactically valid
+        $output = [];
+        $returnCode = 0;
+        exec('php -l ' . escapeshellarg($generatedFile) . ' 2>&1', $output, $returnCode);
+        $this->assertSame(0, $returnCode, 'Generated PHP is not syntactically valid: ' . implode("\n", $output));
+    }
+
+    public function testUnionTypeWithMixed(): void
+    {
+        // Mixed in union is not valid in PHP, but we need to handle it gracefully
+        $configContent = <<<'PHP'
+<?php
+return [
+    'MixedField' => [
+        'fields' => [
+            'data' => 'mixed',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        // Mixed should not generate a type hint (it's PHP 8.0+ standalone, not in unions)
+        $field = $definitions['MixedField']['fields']['data'];
+        $this->assertSame('mixed', $field['type']);
+        $this->assertNull($field['typeHint']);
+    }
+
+    public function testTypeScriptGeneratorWithUnionTypes(): void
+    {
+        $definitions = [
+            'UnionTest' => [
+                'name' => 'UnionTest',
+                'fields' => [
+                    'value' => [
+                        'name' => 'value',
+                        'type' => 'int|string',
+                        'required' => true,
+                    ],
+                    'data' => [
+                        'name' => 'data',
+                        'type' => 'int|float|string',
+                    ],
+                ],
+            ],
+        ];
+
+        $generator = new TypeScriptGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $content = file_get_contents($this->tempDir . '/dto.ts');
+
+        // TypeScript should convert PHP union to TS union
+        $this->assertStringContainsString('value: number | string;', $content);
+        $this->assertStringContainsString('data?: number | string;', $content);
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for PHP 8.0+ union types (`int|string`, `int|float|string`, etc.)
- Generated DTOs now include proper union type hints in method signatures
- Handle nullable union types with `|null` suffix instead of `?` prefix (required for valid PHP syntax)
- Add `Field::union()` fluent builder method for easier configuration
- Update TypeScriptGenerator to convert PHP unions to TypeScript unions

## Changes

### Builder (`src/Generator/Builder.php`)
- Update `typehint()` to return union types instead of `null`
- Add `isUnionType()` helper method
- Handle nullable union types correctly in `_completeMeta()`
- Add `nullableReturnTypeHint` for proper getter return types

### Templates
- Update `method_get.twig` to use pre-computed nullable return type hints

### TypeScript Generator
- Split union types and map each type individually
- Deduplicate mapped types (e.g., `int|float` both map to `number`)

### Fluent Builder
- Add `Field::union('name', 'int', 'string')` method

## Example

```xml
<dto name="Product">
    <field name="id" type="int|string" required="true"/>
    <field name="price" type="int|float"/>
</dto>
```

Generated PHP:
```php
public function setId(int|string $id): self { ... }
public function getId(): int|string { ... }

public function setPrice(int|float|null $price = null): self { ... }
public function getPrice(): int|float|null { ... }
```