### PR TITLE
Add PHPDoc generics for better static analysis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,31 @@ $dto->addItem('key2', $itemTwo);
 $item = $dto->getItem('key1');
 ```
 
+### PHPDoc Generics
+
+Collections and typed arrays use PHPDoc generic syntax for better static analysis support:
+
+```php
+/**
+ * @property \ArrayObject<int, ItemDto> $items
+ * @property array<int, string> $tags
+ */
+class OrderDto extends AbstractDto
+{
+    /**
+     * @var \ArrayObject<int, ItemDto>
+     */
+    protected $items;
+
+    /**
+     * @return \ArrayObject<int, ItemDto>
+     */
+    public function getItems(): \ArrayObject { ... }
+}
+```
+
+PHPStan and Psalm can now properly infer element types in foreach loops and method calls.
+
 ### Deprecations
 
 ```xml

--- a/templates/element/doc.twig
+++ b/templates/element/doc.twig
@@ -1,4 +1,4 @@
  *
 {% for field in fields %}
- * @property {{ field.type }}{% if field.nullable %}|null{% endif %} ${{ field.name }}
+ * @property {{ field.docBlockType ?? field.type }}{% if field.nullable %}|null{% endif %} ${{ field.name }}
 {% endfor -%}

--- a/templates/element/method_get.twig
+++ b/templates/element/method_get.twig
@@ -3,7 +3,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @return {{ type }}{% if nullable %}|null{% endif %}
+	 * @return {{ docBlockType ?? type }}{% if nullable %}|null{% endif %}
 
 	 */
 	public function get{{ name[:1]|upper ~ name[1:] }}(){% if returnTypeHint %}: {% if nullable %}?{% endif %}{{ returnTypeHint }}{% endif %} {

--- a/templates/element/method_get_or_fail.twig
+++ b/templates/element/method_get_or_fail.twig
@@ -5,7 +5,7 @@
 {% endif %}
 	 * @throws \RuntimeException If value is not set.
 	 *
-	 * @return {{ type }}
+	 * @return {{ docBlockType ?? type }}
 	 */
 	public function get{{ name[:1]|upper ~ name[1:] }}OrFail(){% if returnTypeHint %}: {{ returnTypeHint }}{% endif %} {
 		if ($this->{{ name }} === null) {

--- a/templates/element/method_set.twig
+++ b/templates/element/method_set.twig
@@ -3,7 +3,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param {{ type }}{% if nullable %}|null{% endif %} ${{ name }}
+	 * @param {{ docBlockType ?? type }}{% if nullable %}|null{% endif %} ${{ name }}
 	 *
 	 * @return $this
 	 */

--- a/templates/element/method_set_or_fail.twig
+++ b/templates/element/method_set_or_fail.twig
@@ -3,7 +3,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param {{ type }} ${{ name }}
+	 * @param {{ docBlockType ?? type }} ${{ name }}
 {% if not typeHint %}
 	 *
 	 * @throws \RuntimeException If value is not present.

--- a/templates/element/method_with.twig
+++ b/templates/element/method_with.twig
@@ -3,7 +3,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param {{ type }}{% if nullable %}|null{% endif %} ${{ name }}
+	 * @param {{ docBlockType ?? type }}{% if nullable %}|null{% endif %} ${{ name }}
 	 *
 	 * @return static
 	 */

--- a/templates/element/method_with_or_fail.twig
+++ b/templates/element/method_with_or_fail.twig
@@ -3,7 +3,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param {{ type }} ${{ name }}
+	 * @param {{ docBlockType ?? type }} ${{ name }}
 {% if not typeHint %}
 	 *
 	 * @throws \RuntimeException If value is not present.

--- a/templates/element/property.twig
+++ b/templates/element/property.twig
@@ -1,4 +1,4 @@
 	/**
-	 * @var {{ type }}{% if nullable %}|null{% endif ~%}
+	 * @var {{ docBlockType ?? type }}{% if nullable %}|null{% endif ~%}
 	 */
 	protected ${{ name }};

--- a/tests/Generator/GenericPhpDocTest.php
+++ b/tests/Generator/GenericPhpDocTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Engine\PhpEngine;
+use PhpCollective\Dto\Generator\ArrayConfig;
+use PhpCollective\Dto\Generator\Builder;
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\Generator;
+use PhpCollective\Dto\Generator\IoInterface;
+use PhpCollective\Dto\Generator\TwigRenderer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PHPDoc generic type annotations.
+ */
+class GenericPhpDocTest extends TestCase
+{
+    protected string $tempDir;
+
+    /**
+     * @var resource
+     */
+    protected $stdout;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/generic_phpdoc_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        mkdir($this->tempDir . '/config', 0777, true);
+        $this->stdout = fopen('php://memory', 'r+');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+        fclose($this->stdout);
+    }
+
+    protected function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    protected function createIo(): ConsoleIo
+    {
+        return new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stdout);
+    }
+
+    public function testBuilderGeneratesDocBlockTypeForArrayCollection(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Order' => [
+        'fields' => [
+            'items' => [
+                'type' => 'Item[]',
+                'collection' => true,
+                'singular' => 'item',
+            ],
+        ],
+    ],
+    'Item' => [
+        'fields' => [
+            'name' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $itemsField = $definitions['Order']['fields']['items'];
+
+        // Should have generic docBlockType
+        $this->assertArrayHasKey('docBlockType', $itemsField);
+        $this->assertSame('\ArrayObject<int, \App\Dto\ItemDto>', $itemsField['docBlockType']);
+    }
+
+    public function testBuilderGeneratesDocBlockTypeForTypedArray(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'User' => [
+        'fields' => [
+            'tags' => 'string[]',
+            'scores' => 'int[]',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $tagsField = $definitions['User']['fields']['tags'];
+        $scoresField = $definitions['User']['fields']['scores'];
+
+        $this->assertArrayHasKey('docBlockType', $tagsField);
+        $this->assertSame('array<int, string>', $tagsField['docBlockType']);
+
+        $this->assertArrayHasKey('docBlockType', $scoresField);
+        $this->assertSame('array<int, int>', $scoresField['docBlockType']);
+    }
+
+    public function testBuilderGeneratesDocBlockTypeForAssociativeCollection(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Catalog' => [
+        'fields' => [
+            'products' => [
+                'type' => 'Product[]',
+                'collection' => true,
+                'singular' => 'product',
+                'associative' => true,
+            ],
+        ],
+    ],
+    'Product' => [
+        'fields' => [
+            'name' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $productsField = $definitions['Catalog']['fields']['products'];
+
+        // Should have string key type for associative collection
+        $this->assertArrayHasKey('docBlockType', $productsField);
+        $this->assertSame('\ArrayObject<string, \App\Dto\ProductDto>', $productsField['docBlockType']);
+    }
+
+    public function testGeneratedDtoUsesGenericPhpDocTypes(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Order' => [
+        'fields' => [
+            'items' => [
+                'type' => 'Item[]',
+                'collection' => true,
+                'singular' => 'item',
+            ],
+            'tags' => 'string[]',
+        ],
+    ],
+    'Item' => [
+        'fields' => [
+            'name' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'TestApp']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+        $renderer = new TwigRenderer(null, $config);
+
+        $generator = new Generator($builder, $renderer, $this->createIo(), $config);
+        $generator->generate($this->tempDir . '/config/', $this->tempDir . '/src/');
+
+        $generatedFile = $this->tempDir . '/src/Dto/OrderDto.php';
+        $this->assertFileExists($generatedFile);
+
+        $content = file_get_contents($generatedFile);
+
+        // Class-level @property annotations should use generics
+        $this->assertStringContainsString('@property \ArrayObject<int, \TestApp\Dto\ItemDto>', $content);
+        $this->assertStringContainsString('@property array<int, string>', $content);
+
+        // Property @var annotations should use generics
+        $this->assertStringContainsString('@var \ArrayObject<int, \TestApp\Dto\ItemDto>', $content);
+        $this->assertStringContainsString('@var array<int, string>', $content);
+
+        // Method @return annotations should use generics
+        $this->assertStringContainsString('@return \ArrayObject<int, \TestApp\Dto\ItemDto>', $content);
+        $this->assertStringContainsString('@return array<int, string>', $content);
+    }
+
+    public function testGeneratedDtoWithPlainArrayCollectionType(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Order' => [
+        'fields' => [
+            'items' => [
+                'type' => 'Item[]',
+                'collection' => true,
+                'collectionType' => 'array',
+                'singular' => 'item',
+            ],
+        ],
+    ],
+    'Item' => [
+        'fields' => [
+            'name' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'TestApp']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        $itemsField = $definitions['Order']['fields']['items'];
+
+        // Should use array<int, ElementType> when collectionType is 'array'
+        $this->assertArrayHasKey('docBlockType', $itemsField);
+        $this->assertSame('array<int, \TestApp\Dto\ItemDto>', $itemsField['docBlockType']);
+    }
+
+    public function testScalarFieldsDoNotHaveDocBlockType(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'User' => [
+        'fields' => [
+            'id' => 'int',
+            'name' => 'string',
+            'active' => 'bool',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        // Scalar fields should not have docBlockType set
+        $this->assertArrayNotHasKey('docBlockType', $definitions['User']['fields']['id']);
+        $this->assertArrayNotHasKey('docBlockType', $definitions['User']['fields']['name']);
+        $this->assertArrayNotHasKey('docBlockType', $definitions['User']['fields']['active']);
+    }
+}


### PR DESCRIPTION
## Summary

- Generate PHPDoc generic type annotations for collections and typed arrays
- Enables better static analysis with PHPStan and Psalm
- Element types can now be properly inferred in foreach loops and method calls

## Changes

### Before
```php
/**
 * @var ItemDto[]|\ArrayObject
 */
protected $items;

/**
 * @var string[]
 */
protected $tags;
```

### After
```php
/**
 * @var \ArrayObject<int, ItemDto>
 */
protected $items;

/**
 * @var array<int, string>
 */
protected $tags;
```

### Details

- `buildGenericArrayType()` - converts typed arrays to `array<int, ElementType>`
- `buildGenericCollectionType()` - converts collections to `\ArrayObject<int, ElementType>`
- Associative collections use `string` key type
- All templates updated to use `docBlockType ?? type` for @var, @param, @return
- Added 6 comprehensive tests

### Benefits

- PHPStan/Psalm can now infer element types correctly
- Better IDE autocomplete in foreach loops
- No runtime changes - only PHPDoc annotations