### PR TITLE
Add Schema Importer for bootstrapping DTO configs from JSON

### DIFF
--- a/docs/Importer.md
+++ b/docs/Importer.md
@@ -1,0 +1,244 @@
+# Schema Importer
+
+The Importer utility helps you quickly bootstrap DTO configurations from existing JSON data or JSON Schema definitions. This is useful when integrating with external APIs or migrating from other systems.
+
+## Quick Start
+
+```php
+use PhpCollective\Dto\Importer\Importer;
+
+$importer = new Importer();
+
+// From JSON data example
+$json = '{"name": "John", "age": 30, "email": "john@example.com"}';
+echo $importer->import($json);
+```
+
+Output (PHP config format):
+```php
+<?php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\DtoBuilder;
+use PhpCollective\Dto\Config\Field;
+
+return DtoBuilder::create()
+    ->dtos(
+        Dto::create('Object')->fields(
+            Field::string('name'),
+            Field::int('age'),
+            Field::string('email'),
+        ),
+    )
+    ->build();
+```
+
+## Input Types
+
+The Importer supports two input types:
+
+### 1. JSON Data (auto-detected)
+
+Pass an example JSON response and the importer will infer types:
+
+```php
+$json = '{
+    "user": {
+        "name": "John",
+        "email": "john@example.com"
+    },
+    "items": [
+        {"id": 1, "name": "Item 1"},
+        {"id": 2, "name": "Item 2"}
+    ]
+}';
+
+$result = $importer->import($json);
+```
+
+Features:
+- Infers scalar types (string, int, float, bool)
+- Detects nested objects and creates separate DTOs
+- Detects arrays of objects (collections)
+- Auto-detects potential associative array keys (slug, name, id, login)
+- Converts field names to camelCase
+
+### 2. JSON Schema
+
+Pass a JSON Schema definition for more precise control:
+
+```php
+$schema = json_encode([
+    'type' => 'object',
+    'title' => 'User',
+    'properties' => [
+        'name' => ['type' => 'string'],
+        'age' => ['type' => 'integer'],
+        'email' => ['type' => 'string'],
+    ],
+    'required' => ['name', 'email'],
+]);
+
+$result = $importer->import($schema);
+```
+
+Features:
+- Uses `title` for DTO name
+- Respects `required` array for field validation
+- Handles `anyOf`/`oneOf` type unions
+- Processes nested `$ref` definitions (skipped for manual handling)
+- Normalizes types (integer→int, boolean→bool, number→float)
+
+## Output Formats
+
+### PHP (default)
+
+```php
+$importer->import($json, ['format' => 'php']);
+```
+
+### XML
+
+```php
+$importer->import($json, ['format' => 'xml']);
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="https://php-collective.github.io/dto/schema">
+    <dto name="User">
+        <field name="name" type="string" required="true"/>
+        <field name="email" type="string"/>
+    </dto>
+</dtos>
+```
+
+### YAML
+
+```php
+$importer->import($json, ['format' => 'yaml']);
+```
+
+```yaml
+User:
+  fields:
+    name:
+      type: string
+      required: true
+    email:
+      type: string
+```
+
+### NEON
+
+```php
+$importer->import($json, ['format' => 'neon']);
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `type` | Force parser type: `'Data'` or `'Schema'` | Auto-detected |
+| `format` | Output format: `'php'`, `'xml'`, `'yaml'`, `'neon'` | `'php'` |
+| `namespace` | Namespace prefix for generated DTOs | None |
+
+### Namespace Example
+
+```php
+$importer->import($json, ['namespace' => 'Api/Response']);
+```
+
+Generates DTOs like `Api/Response/User`, `Api/Response/Address`, etc.
+
+## Step-by-Step Usage
+
+For more control, you can use the two-step process:
+
+```php
+// Step 1: Parse to intermediate format
+$definitions = $importer->parse($json, ['type' => 'Data']);
+
+// Inspect or modify definitions
+var_dump($definitions);
+// [
+//     'User' => [
+//         'name' => ['type' => 'string'],
+//         'age' => ['type' => 'int'],
+//     ],
+// ]
+
+// Step 2: Build schema output
+$schema = $importer->buildSchema($definitions, ['format' => 'xml']);
+```
+
+### Working with Arrays
+
+```php
+// Parse array directly (no JSON encoding needed)
+$data = ['name' => 'John', 'age' => 30];
+$definitions = $importer->parseArray($data);
+
+// Or use the convenience method
+$schema = $importer->importArray($data, ['format' => 'php']);
+```
+
+## Type Inference
+
+### From JSON Data
+
+| JSON Value | Inferred Type |
+|------------|---------------|
+| `"string"` | `string` |
+| `123` | `int` |
+| `12.34` | `float` |
+| `true`/`false` | `bool` |
+| `null` | `mixed` |
+| `{...}` | Nested DTO |
+| `[{...}, {...}]` | Collection (`Dto[]`) |
+| `["a", "b"]` | `array` |
+
+### From JSON Schema
+
+| JSON Schema Type | DTO Type |
+|------------------|----------|
+| `string` | `string` |
+| `integer` | `int` |
+| `number` | `float` |
+| `boolean` | `bool` |
+| `array` (of objects) | Collection |
+| `object` | Nested DTO |
+| `["string", "null"]` | `string` (optional) |
+
+## Limitations
+
+The importer is a scaffolding tool. Generated configs typically need manual refinement:
+
+1. **No enum detection** - Enums are imported as `string`
+2. **No custom types** - DateTime, custom classes need manual configuration
+3. **Limited validation** - Only `required` from JSON Schema is used
+4. **Type inference from data** - Single example may not represent all cases
+5. **No `$ref` resolution** - Schema references are skipped
+
+## Example: API Response
+
+```php
+// Fetch from API
+$response = file_get_contents('https://api.example.com/users/1');
+
+// Generate DTO config
+$importer = new Importer();
+$config = $importer->import($response, [
+    'namespace' => 'Api/User',
+    'format' => 'php',
+]);
+
+// Save to config file
+file_put_contents('config/dto/api-user.php', $config);
+```
+
+Then review and refine the generated config:
+- Add `required()` to mandatory fields
+- Change types for enums, dates, etc.
+- Add `mapFrom()`/`mapTo()` for field name mapping
+- Configure `factory()`/`serialize()` for custom types

--- a/src/Importer/Builder/BuilderInterface.php
+++ b/src/Importer/Builder/BuilderInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer\Builder;
+
+/**
+ * Interface for schema builders that convert parsed definitions to config format.
+ */
+interface BuilderInterface
+{
+    /**
+     * Build schema output for a single DTO.
+     *
+     * @param string $name DTO name
+     * @param array<string, array<string, mixed>> $fields Field definitions
+     * @param array<string, mixed> $options
+     *
+     * @return string
+     */
+    public function build(string $name, array $fields, array $options = []): string;
+
+    /**
+     * Build complete schema output for multiple DTOs.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $definitions
+     * @param array<string, mixed> $options
+     *
+     * @return string
+     */
+    public function buildAll(array $definitions, array $options = []): string;
+}

--- a/src/Importer/Builder/SchemaBuilder.php
+++ b/src/Importer/Builder/SchemaBuilder.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer\Builder;
+
+/**
+ * Builds DTO schema configuration in various formats.
+ */
+class SchemaBuilder implements BuilderInterface
+{
+    /**
+     * @var string
+     */
+    public const FORMAT_XML = 'xml';
+
+    /**
+     * @var string
+     */
+    public const FORMAT_PHP = 'php';
+
+    /**
+     * @var string
+     */
+    public const FORMAT_YAML = 'yaml';
+
+    /**
+     * @var string
+     */
+    public const FORMAT_NEON = 'neon';
+
+    /**
+     * @inheritDoc
+     */
+    public function build(string $name, array $fields, array $options = []): string
+    {
+        $format = $options['format'] ?? self::FORMAT_PHP;
+
+        return match ($format) {
+            self::FORMAT_XML => $this->buildXml($name, $fields),
+            self::FORMAT_YAML => $this->buildYaml($name, $fields),
+            self::FORMAT_NEON => $this->buildNeon($name, $fields),
+            default => $this->buildPhp($name, $fields),
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildAll(array $definitions, array $options = []): string
+    {
+        $format = $options['format'] ?? self::FORMAT_PHP;
+
+        // Filter out excluded definitions
+        $filtered = [];
+        foreach ($definitions as $name => $fields) {
+            if (isset($fields['_include']) && !$fields['_include']) {
+                continue;
+            }
+            unset($fields['_include']);
+            $filtered[$name] = $fields;
+        }
+
+        return match ($format) {
+            self::FORMAT_XML => $this->buildAllXml($filtered),
+            self::FORMAT_YAML => $this->buildAllYaml($filtered),
+            self::FORMAT_NEON => $this->buildAllNeon($filtered),
+            default => $this->buildAllPhp($filtered),
+        };
+    }
+
+    /**
+     * Build XML output for a single DTO.
+     *
+     * @param string $name
+     * @param array<string, array<string, mixed>> $fields
+     *
+     * @return string
+     */
+    protected function buildXml(string $name, array $fields): string
+    {
+        $fieldLines = [];
+        foreach ($fields as $fieldName => $fieldDetails) {
+            if (isset($fieldDetails['_include']) && !$fieldDetails['_include']) {
+                continue;
+            }
+
+            $attr = [
+                'name="' . $this->escapeXml($fieldName) . '"',
+                'type="' . $this->escapeXml($fieldDetails['type'] ?? 'mixed') . '"',
+            ];
+
+            if (!empty($fieldDetails['required'])) {
+                $attr[] = 'required="true"';
+            }
+            if (!empty($fieldDetails['singular'])) {
+                $attr[] = 'singular="' . $this->escapeXml($fieldDetails['singular']) . '"';
+            }
+            if (!empty($fieldDetails['associative'])) {
+                $attr[] = 'associative="true"';
+                $attr[] = 'key="' . $this->escapeXml($fieldDetails['associative']) . '"';
+            }
+
+            $fieldLines[] = "\t\t" . '<field ' . implode(' ', $attr) . '/>';
+        }
+
+        $fieldsStr = implode("\n", $fieldLines);
+
+        return <<<XML
+	<dto name="{$name}">
+{$fieldsStr}
+	</dto>
+XML;
+    }
+
+    /**
+     * Build XML output for all DTOs.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $definitions
+     *
+     * @return string
+     */
+    protected function buildAllXml(array $definitions): string
+    {
+        $dtos = [];
+        foreach ($definitions as $name => $fields) {
+            $dtos[] = $this->buildXml($name, $fields);
+        }
+
+        $dtosStr = implode("\n", $dtos);
+
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="https://php-collective.github.io/dto/schema">
+{$dtosStr}
+</dtos>
+XML;
+    }
+
+    /**
+     * Build PHP output for a single DTO.
+     *
+     * @param string $name
+     * @param array<string, array<string, mixed>> $fields
+     *
+     * @return string
+     */
+    protected function buildPhp(string $name, array $fields): string
+    {
+        $fieldLines = [];
+        foreach ($fields as $fieldName => $fieldDetails) {
+            if (isset($fieldDetails['_include']) && !$fieldDetails['_include']) {
+                continue;
+            }
+
+            $type = $fieldDetails['type'] ?? 'mixed';
+            $required = !empty($fieldDetails['required']);
+
+            // Determine the Field:: method to use
+            $method = $this->getFieldMethod($type);
+            $line = "            Field::{$method}('{$fieldName}')";
+
+            if ($required) {
+                $line .= '->required()';
+            }
+
+            if (!empty($fieldDetails['singular'])) {
+                $line .= "->singular('{$fieldDetails['singular']}')";
+            }
+            if (!empty($fieldDetails['associative'])) {
+                $line .= "->associative('{$fieldDetails['associative']}')";
+            }
+
+            $fieldLines[] = $line . ',';
+        }
+
+        $fieldsStr = implode("\n", $fieldLines);
+
+        return <<<PHP
+        Dto::create('{$name}')->fields(
+{$fieldsStr}
+        ),
+PHP;
+    }
+
+    /**
+     * Build PHP output for all DTOs.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $definitions
+     *
+     * @return string
+     */
+    protected function buildAllPhp(array $definitions): string
+    {
+        $dtos = [];
+        foreach ($definitions as $name => $fields) {
+            $dtos[] = $this->buildPhp($name, $fields);
+        }
+
+        $dtosStr = implode("\n", $dtos);
+
+        return <<<PHP
+<?php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\DtoBuilder;
+use PhpCollective\Dto\Config\Field;
+
+return DtoBuilder::create()
+    ->dtos(
+{$dtosStr}
+    )
+    ->build();
+PHP;
+    }
+
+    /**
+     * Build YAML output for a single DTO.
+     *
+     * @param string $name
+     * @param array<string, array<string, mixed>> $fields
+     *
+     * @return string
+     */
+    protected function buildYaml(string $name, array $fields): string
+    {
+        $lines = ["{$name}:"];
+        $lines[] = '  fields:';
+
+        foreach ($fields as $fieldName => $fieldDetails) {
+            if (isset($fieldDetails['_include']) && !$fieldDetails['_include']) {
+                continue;
+            }
+
+            $lines[] = "    {$fieldName}:";
+            $lines[] = "      type: {$fieldDetails['type']}";
+
+            if (!empty($fieldDetails['required'])) {
+                $lines[] = '      required: true';
+            }
+            if (!empty($fieldDetails['singular'])) {
+                $lines[] = "      singular: {$fieldDetails['singular']}";
+            }
+            if (!empty($fieldDetails['associative'])) {
+                $lines[] = '      associative: true';
+                $lines[] = "      key: {$fieldDetails['associative']}";
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Build YAML output for all DTOs.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $definitions
+     *
+     * @return string
+     */
+    protected function buildAllYaml(array $definitions): string
+    {
+        $dtos = [];
+        foreach ($definitions as $name => $fields) {
+            $dtos[] = $this->buildYaml($name, $fields);
+        }
+
+        return implode("\n\n", $dtos) . "\n";
+    }
+
+    /**
+     * Build NEON output for a single DTO.
+     *
+     * @param string $name
+     * @param array<string, array<string, mixed>> $fields
+     *
+     * @return string
+     */
+    protected function buildNeon(string $name, array $fields): string
+    {
+        // NEON format is similar to YAML
+        return $this->buildYaml($name, $fields);
+    }
+
+    /**
+     * Build NEON output for all DTOs.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $definitions
+     *
+     * @return string
+     */
+    protected function buildAllNeon(array $definitions): string
+    {
+        return $this->buildAllYaml($definitions);
+    }
+
+    /**
+     * Get the Field:: method name for a type.
+     *
+     * @param string $type
+     *
+     * @return string
+     */
+    protected function getFieldMethod(string $type): string
+    {
+        // Handle collection types
+        if (str_ends_with($type, '[]')) {
+            $baseType = substr($type, 0, -2);
+            // If it's a DTO type (starts with uppercase), use dtos()
+            if (ctype_upper($baseType[0])) {
+                return "dtos('{$baseType}')";
+            }
+
+            return match ($baseType) {
+                'string' => 'strings',
+                'int' => 'ints',
+                'float' => 'floats',
+                'bool' => 'bools',
+                default => "collection('{$type}')",
+            };
+        }
+
+        // Handle DTO types (starts with uppercase)
+        if (ctype_upper($type[0])) {
+            return "dto('{$type}')";
+        }
+
+        return match ($type) {
+            'string' => 'string',
+            'int' => 'int',
+            'float' => 'float',
+            'bool' => 'bool',
+            'array' => 'array',
+            'mixed' => 'mixed',
+            default => "field('{$type}')",
+        };
+    }
+
+    /**
+     * Escape special characters for XML.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected function escapeXml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer;
+
+use PhpCollective\Dto\Importer\Builder\SchemaBuilder;
+use PhpCollective\Dto\Importer\Parser\DataParser;
+use PhpCollective\Dto\Importer\Parser\SchemaParser;
+
+/**
+ * Main importer class for generating DTO schemas from JSON data or JSON Schema.
+ *
+ * Usage:
+ *
+ * ```php
+ * $importer = new Importer();
+ *
+ * // From JSON data example
+ * $json = '{"name": "John", "age": 30}';
+ * $result = $importer->parse($json);
+ * echo $importer->buildSchema($result);
+ *
+ * // From JSON Schema
+ * $schema = file_get_contents('schema.json');
+ * $result = $importer->parse($schema, ['type' => 'Schema']);
+ * echo $importer->buildSchema($result, ['format' => 'xml']);
+ * ```
+ */
+class Importer
+{
+    /**
+     * Parse JSON input and return DTO definitions.
+     *
+     * Auto-detects whether input is JSON data or JSON Schema.
+     *
+     * @param string $json JSON string to parse
+     * @param array<string, mixed> $options Options:
+     *   - type: 'Data' or 'Schema' (auto-detected if not provided)
+     *   - namespace: Namespace prefix for generated DTOs
+     *
+     * @return array<string, array<string, array<string, mixed>>> Parsed DTO definitions
+     */
+    public function parse(string $json, array $options = []): array
+    {
+        $array = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        if (!$array) {
+            return [];
+        }
+
+        if (empty($options['type'])) {
+            $options['type'] = $this->guessType($array);
+        }
+
+        return ParserFactory::create($options['type'])->parse($array, $options)->result();
+    }
+
+    /**
+     * Parse array input and return DTO definitions.
+     *
+     * @param array<string, mixed> $data Data array to parse
+     * @param array<string, mixed> $options Same options as parse()
+     *
+     * @return array<string, array<string, array<string, mixed>>> Parsed DTO definitions
+     */
+    public function parseArray(array $data, array $options = []): array
+    {
+        if (!$data) {
+            return [];
+        }
+
+        if (empty($options['type'])) {
+            $options['type'] = $this->guessType($data);
+        }
+
+        return ParserFactory::create($options['type'])->parse($data, $options)->result();
+    }
+
+    /**
+     * Build DTO schema configuration from parsed definitions.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $definitions Parsed definitions from parse()
+     * @param array<string, mixed> $options Options:
+     *   - format: 'php' (default), 'xml', 'yaml', or 'neon'
+     *
+     * @return string Generated schema configuration
+     */
+    public function buildSchema(array $definitions, array $options = []): string
+    {
+        $builder = new SchemaBuilder();
+
+        return $builder->buildAll($definitions, $options);
+    }
+
+    /**
+     * Convenience method to parse JSON and build schema in one call.
+     *
+     * @param string $json JSON string to parse
+     * @param array<string, mixed> $options Combined options for parse() and buildSchema()
+     *
+     * @return string Generated schema configuration
+     */
+    public function import(string $json, array $options = []): string
+    {
+        $definitions = $this->parse($json, $options);
+
+        return $this->buildSchema($definitions, $options);
+    }
+
+    /**
+     * Convenience method to parse array and build schema in one call.
+     *
+     * @param array<string, mixed> $data Data array to parse
+     * @param array<string, mixed> $options Combined options for parseArray() and buildSchema()
+     *
+     * @return string Generated schema configuration
+     */
+    public function importArray(array $data, array $options = []): string
+    {
+        $definitions = $this->parseArray($data, $options);
+
+        return $this->buildSchema($definitions, $options);
+    }
+
+    /**
+     * Guess whether input is JSON Schema or plain data.
+     *
+     * @param array<string, mixed> $array
+     *
+     * @return string Parser type name
+     */
+    protected function guessType(array $array): string
+    {
+        // JSON Schema typically has type: object and properties
+        if (!empty($array['type']) && $array['type'] === 'object' && !empty($array['properties'])) {
+            return SchemaParser::NAME;
+        }
+
+        // Check for $schema which is common in JSON Schema
+        if (!empty($array['$schema'])) {
+            return SchemaParser::NAME;
+        }
+
+        return DataParser::NAME;
+    }
+}

--- a/src/Importer/Parser/Config.php
+++ b/src/Importer/Parser/Config.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer\Parser;
+
+/**
+ * Configuration for schema parsers.
+ */
+class Config
+{
+    /**
+     * @var array<string>
+     */
+    protected static array $keyFields = [
+        'slug',
+        'login',
+        'name',
+        'id',
+    ];
+
+    /**
+     * Returns available parser type labels.
+     *
+     * @return array<string, string>
+     */
+    public static function typeLabels(): array
+    {
+        return [
+            DataParser::NAME => 'From JSON Data Example',
+            SchemaParser::NAME => 'From JSON Schema File',
+        ];
+    }
+
+    /**
+     * Returns available parser types.
+     *
+     * @return array<string, class-string<\PhpCollective\Dto\Importer\Parser\ParserInterface>>
+     */
+    public static function types(): array
+    {
+        return [
+            DataParser::NAME => DataParser::class,
+            SchemaParser::NAME => SchemaParser::class,
+        ];
+    }
+
+    /**
+     * Returns fields that can be used as associative array keys.
+     *
+     * @return array<string>
+     */
+    public static function keyFields(): array
+    {
+        return static::$keyFields;
+    }
+
+    /**
+     * Sets custom key fields.
+     *
+     * @param array<string> $fields
+     *
+     * @return void
+     */
+    public static function setKeyFields(array $fields): void
+    {
+        static::$keyFields = $fields;
+    }
+}

--- a/src/Importer/Parser/DataParser.php
+++ b/src/Importer/Parser/DataParser.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer\Parser;
+
+use PhpCollective\Dto\Utility\Inflector;
+
+/**
+ * Parser that infers DTO schema from example JSON data.
+ */
+class DataParser implements ParserInterface
+{
+    /**
+     * @var string
+     */
+    public const NAME = 'Data';
+
+    /**
+     * @var array<string, array<string, array<string, mixed>>>
+     */
+    protected array $result = [];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    protected array $map = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(array $input, array $options = [], array $parentData = []): static
+    {
+        $dtoName = 'Object';
+        if ($parentData) {
+            $field = $parentData['field'];
+            if (!empty($parentData['collection'])) {
+                $field = Inflector::singularize($field);
+            }
+            $dtoName = ucfirst($field);
+        }
+
+        if (!empty($options['namespace'])) {
+            $dtoName = rtrim($options['namespace'], '/') . '/' . $dtoName;
+        }
+
+        $fields = [];
+
+        foreach ($input as $fieldName => $value) {
+            $fieldDetails = [
+                'value' => $value,
+            ];
+
+            // Skip private/internal fields
+            if (str_starts_with((string)$fieldName, '_')) {
+                continue;
+            }
+
+            $fieldName = Inflector::variable((string)$fieldName);
+
+            if (is_array($value)) {
+                if ($this->isAssoc($value)) {
+                    // Nested object
+                    $parseDetails = ['dto' => $dtoName, 'field' => $fieldName];
+                    $this->parse($value, $options, $parseDetails);
+                } elseif ($this->isNumericKeyed($value) && $this->hasAssocValues($value)) {
+                    // Array of objects (collection)
+                    $parseDetails = ['dto' => $dtoName, 'field' => $fieldName];
+                    $parseDetails['collection'] = true;
+
+                    $this->parse($value[0], $options, $parseDetails);
+                    $fieldDetails['collection'] = true;
+                }
+            }
+
+            $type = $this->type($value);
+            if (!empty($fieldDetails['collection'])) {
+                $type = 'object';
+            }
+
+            $fieldDetails['type'] = $type;
+
+            if (isset($this->map[$dtoName][$fieldName])) {
+                $fieldDetails['type'] = $this->map[$dtoName][$fieldName];
+                if (!empty($fieldDetails['collection'])) {
+                    $singular = Inflector::singularize($fieldName);
+                    // Skip on conflicting/existing field
+                    if (!isset($this->map[$dtoName][$singular])) {
+                        $fieldDetails['singular'] = $singular;
+                    }
+
+                    $keyField = $this->detectKeyField($value[0] ?? []);
+                    if ($keyField) {
+                        $fieldDetails['associative'] = $keyField;
+                    }
+                    $fieldDetails['type'] .= '[]';
+                }
+            }
+
+            // Remove internal value key for final output
+            unset($fieldDetails['value']);
+
+            $fields[$fieldName] = $fieldDetails;
+        }
+
+        $this->result[$dtoName] = $fields;
+        if ($parentData) {
+            /** @var string $parentDtoName */
+            $parentDtoName = $parentData['dto'];
+            /** @var string $parentFieldName */
+            $parentFieldName = $parentData['field'];
+            $this->map[$parentDtoName][$parentFieldName] = $dtoName;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function result(): array
+    {
+        return $this->result;
+    }
+
+    /**
+     * Infer type from value.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function type(mixed $value): string
+    {
+        $type = gettype($value);
+
+        if ($type === 'NULL') {
+            return 'mixed';
+        }
+
+        return $this->normalize($type);
+    }
+
+    /**
+     * Normalize PHP type names to DTO type names.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function normalize(string $name): string
+    {
+        return match ($name) {
+            'boolean' => 'bool',
+            'real', 'double' => 'float',
+            'integer' => 'int',
+            '[]' => 'array',
+            default => $name,
+        };
+    }
+
+    /**
+     * Check if array is associative (object-like).
+     *
+     * @param array<mixed> $value
+     *
+     * @return bool
+     */
+    protected function isAssoc(array $value): bool
+    {
+        foreach ($value as $k => $v) {
+            if (!is_string($k)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if array has numeric keys (list-like).
+     *
+     * @param array<mixed> $value
+     *
+     * @return bool
+     */
+    protected function isNumericKeyed(array $value): bool
+    {
+        foreach ($value as $k => $v) {
+            if (!is_int($k)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if array contains associative arrays.
+     *
+     * @param array<mixed> $value
+     *
+     * @return bool
+     */
+    protected function hasAssocValues(array $value): bool
+    {
+        foreach ($value as $v) {
+            if (!is_array($v) || !$this->isAssoc($v)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Detect potential key field for associative arrays.
+     *
+     * @param array<string, mixed> $value
+     *
+     * @return string|null
+     */
+    protected function detectKeyField(array $value): ?string
+    {
+        $strings = Config::keyFields();
+        foreach ($strings as $string) {
+            if (isset($value[$string]) && is_string($value[$string])) {
+                return $string;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Importer/Parser/ParserInterface.php
+++ b/src/Importer/Parser/ParserInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer\Parser;
+
+/**
+ * Interface for schema parsers that convert input data to DTO definitions.
+ */
+interface ParserInterface
+{
+    /**
+     * Translates input into DTO field definitions.
+     *
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $options
+     *
+     * @return $this
+     */
+    public function parse(array $input, array $options = []): static;
+
+    /**
+     * Returns the parsed result.
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    public function result(): array;
+}

--- a/src/Importer/Parser/SchemaParser.php
+++ b/src/Importer/Parser/SchemaParser.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer\Parser;
+
+use PhpCollective\Dto\Utility\Inflector;
+
+/**
+ * Parser that converts JSON Schema definitions to DTO schema.
+ */
+class SchemaParser implements ParserInterface
+{
+    /**
+     * @var string
+     */
+    public const NAME = 'Schema';
+
+    /**
+     * @var array<string, array<string, array<string, mixed>>>
+     */
+    protected array $result = [];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    protected array $map = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(array $input, array $options = [], array $parentData = []): static
+    {
+        if (!$input || empty($input['properties'])) {
+            return $this;
+        }
+
+        $dtoName = !empty($input['title']) ? Inflector::camelize($input['title']) : null;
+        if (!$dtoName) {
+            if (empty($parentData['field'])) {
+                $parentData['field'] = '';
+            }
+            $field = $parentData['field'];
+            if (!empty($parentData['collection'])) {
+                $field = Inflector::singularize($field);
+            }
+            $dtoName = $field ? ucfirst($field) : 'Object';
+        }
+
+        if (!empty($options['namespace'])) {
+            $dtoName = rtrim($options['namespace'], '/') . '/' . $dtoName;
+        }
+
+        $fields = [];
+        $requiredFields = $input['required'] ?? [];
+
+        foreach ($input['properties'] as $fieldName => $details) {
+            if (str_starts_with($fieldName, '_') || !empty($details['$ref'])) {
+                continue;
+            }
+            if (!is_array($details)) {
+                continue;
+            }
+
+            $required = in_array($fieldName, $requiredFields, true);
+
+            // Handle anyOf/oneOf type unions
+            if (!isset($details['type']) && !empty($details['anyOf'])) {
+                $details['type'] = $this->guessType($details['anyOf']);
+                if (in_array('object', $details['type'], true)) {
+                    $details = $this->detailsFromObject($details, 'anyOf');
+                }
+            }
+            if (!isset($details['type']) && !empty($details['oneOf'])) {
+                $details['type'] = $this->guessType($details['oneOf']);
+                if (in_array('object', $details['type'], true)) {
+                    $details = $this->detailsFromObject($details, 'oneOf');
+                }
+            }
+
+            // Handle enum without explicit type
+            if (!isset($details['type']) && !empty($details['enum'])) {
+                $details['type'] = 'string';
+            }
+
+            // Handle array type in union
+            if (!empty($details['type']) && is_array($details['type']) && in_array('array', $details['type'], true)) {
+                $details['type'] = 'array';
+                $required = false;
+            }
+
+            // Handle array of objects (collection)
+            if (!empty($details['type']) && $details['type'] === 'array' && !empty($details['items']['type']) && $details['items']['type'] === 'object') {
+                $details['collection'] = true;
+                $details['type'] = 'object';
+                $details['properties'] = $details['items']['properties'] ?? [];
+                $details['required'] = $details['items']['required'] ?? null;
+            }
+
+            // Handle type arrays (union types with null)
+            if (!empty($details['type']) && is_array($details['type'])) {
+                // Remove null from type array and mark as optional
+                if (in_array('null', $details['type'], true)) {
+                    $details['type'] = array_values(array_filter($details['type'], fn ($t) => $t !== 'null'));
+                    $required = false;
+                }
+
+                // Flatten nested arrays, normalize each type, and join with |
+                $details['type'] = $this->flattenTypes($details['type']);
+                $details['type'] = array_map(fn ($t) => $this->normalize($t), $details['type']);
+                $type = implode('|', $details['type']);
+                $details['type'] = $type;
+            }
+
+            if (!isset($details['type']) || $details['type'] === '') {
+                $details['type'] = 'mixed';
+            }
+
+            $fieldName = Inflector::variable($fieldName);
+
+            $fieldDetails = [
+                'type' => $this->type($details['type']),
+                'required' => $required,
+            ];
+
+            // Handle nested objects
+            if ($fieldDetails['type'] === 'object') {
+                $parseDetails = ['dto' => $dtoName, 'field' => $fieldName];
+                if (!empty($details['collection'])) {
+                    $parseDetails['collection'] = $details['collection'];
+                }
+                $this->parse($details, $options, $parseDetails);
+
+                if (isset($this->map[$dtoName][$fieldName])) {
+                    $fieldDetails['type'] = $this->map[$dtoName][$fieldName];
+                    if (!empty($details['collection'])) {
+                        $singular = Inflector::singularize($fieldName);
+                        // Skip on conflicting/existing field
+                        if (!isset($this->map[$dtoName][$singular])) {
+                            $fieldDetails['singular'] = $singular;
+                        }
+                        $dtoFields = $details['items']['properties'] ?? [];
+                        $keyField = $this->detectKeyField($dtoFields);
+                        if ($keyField) {
+                            $fieldDetails['associative'] = $keyField;
+                        }
+                        $fieldDetails['type'] .= '[]';
+                    }
+                }
+            }
+
+            $fields[$fieldName] = $fieldDetails;
+        }
+
+        $this->result[$dtoName] = $fields;
+        if ($parentData) {
+            /** @var string $parentDtoName */
+            $parentDtoName = $parentData['dto'] ?? null;
+            /** @var string $parentFieldName */
+            $parentFieldName = $parentData['field'];
+            $this->map[$parentDtoName][$parentFieldName] = $dtoName;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function result(): array
+    {
+        return $this->result;
+    }
+
+    /**
+     * Normalize type name.
+     *
+     * @param string $type
+     *
+     * @return string
+     */
+    protected function type(string $type): string
+    {
+        return $this->normalize($type);
+    }
+
+    /**
+     * Normalize JSON Schema type names to DTO type names.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function normalize(string $name): string
+    {
+        return match ($name) {
+            'boolean' => 'bool',
+            'real', 'double', 'number' => 'float',
+            'integer' => 'int',
+            '[]' => 'array',
+            default => $name,
+        };
+    }
+
+    /**
+     * Extract types from anyOf/oneOf array.
+     *
+     * @param array<int, array<string, mixed>> $anyOf
+     *
+     * @return array<string>
+     */
+    protected function guessType(array $anyOf): array
+    {
+        $types = [];
+        foreach ($anyOf as $item) {
+            if (isset($item['type'])) {
+                $types[] = $item['type'];
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * Extract object details from anyOf/oneOf.
+     *
+     * @param array<string, mixed> $details
+     * @param string $key 'anyOf' or 'oneOf'
+     *
+     * @return array<string, mixed>
+     */
+    protected function detailsFromObject(array $details, string $key): array
+    {
+        if (empty($details[$key])) {
+            return $details;
+        }
+
+        foreach ($details[$key] as $item) {
+            if (empty($item['type'])) {
+                continue;
+            }
+
+            if ($item['type'] !== 'object') {
+                continue;
+            }
+
+            $details['properties'] = $item['properties'] ?? [];
+            $details['required'] = $item['required'] ?? null;
+            $details['title'] = $item['title'] ?? null;
+        }
+
+        return $details;
+    }
+
+    /**
+     * Flatten nested type arrays.
+     *
+     * @param array<mixed> $types
+     *
+     * @return array<string>
+     */
+    protected function flattenTypes(array $types): array
+    {
+        $result = [];
+        foreach ($types as $type) {
+            if (is_array($type)) {
+                $result = array_merge($result, $this->flattenTypes($type));
+            } else {
+                $result[] = $type;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Detect potential key field for associative arrays.
+     *
+     * @param array<string, mixed> $dtoFields
+     *
+     * @return string|null
+     */
+    protected function detectKeyField(array $dtoFields): ?string
+    {
+        $strings = Config::keyFields();
+        foreach ($strings as $string) {
+            if (!empty($dtoFields[$string]) && !empty($dtoFields[$string]['type']) && $dtoFields[$string]['type'] === 'string') {
+                return $string;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Importer/ParserFactory.php
+++ b/src/Importer/ParserFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Importer;
+
+use InvalidArgumentException;
+use PhpCollective\Dto\Importer\Parser\Config;
+use PhpCollective\Dto\Importer\Parser\ParserInterface;
+
+/**
+ * Factory for creating schema parsers.
+ */
+class ParserFactory
+{
+    /**
+     * Create a parser instance by type.
+     *
+     * @param string $type Parser type name
+     *
+     * @throws \InvalidArgumentException If type is unknown
+     *
+     * @return \PhpCollective\Dto\Importer\Parser\ParserInterface
+     */
+    public static function create(string $type): ParserInterface
+    {
+        $types = Config::types();
+        $class = $types[$type] ?? null;
+
+        if ($class === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown parser type "%s". Available types: %s',
+                $type,
+                implode(', ', array_keys($types)),
+            ));
+        }
+
+        return new $class();
+    }
+}

--- a/tests/Importer/Builder/SchemaBuilderTest.php
+++ b/tests/Importer/Builder/SchemaBuilderTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Importer\Builder;
+
+use PhpCollective\Dto\Importer\Builder\SchemaBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for SchemaBuilder.
+ */
+class SchemaBuilderTest extends TestCase
+{
+    protected SchemaBuilder $builder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->builder = new SchemaBuilder();
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhp(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string'],
+            'age' => ['type' => 'int'],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("Dto::create('User')", $output);
+        $this->assertStringContainsString("Field::string('name')", $output);
+        $this->assertStringContainsString("Field::int('age')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhpWithRequired(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string', 'required' => true],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::string('name')->required()", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhpWithSingular(): void
+    {
+        $fields = [
+            'items' => ['type' => 'Item[]', 'singular' => 'item'],
+        ];
+
+        $output = $this->builder->build('Order', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("->singular('item')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhpWithAssociative(): void
+    {
+        $fields = [
+            'users' => ['type' => 'User[]', 'associative' => 'slug'],
+        ];
+
+        $output = $this->builder->build('Group', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("->associative('slug')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildAllPhp(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => ['type' => 'string'],
+            ],
+            'Order' => [
+                'id' => ['type' => 'int'],
+            ],
+        ];
+
+        $output = $this->builder->buildAll($definitions, ['format' => 'php']);
+
+        $this->assertStringContainsString('DtoBuilder::create()', $output);
+        $this->assertStringContainsString("Dto::create('User')", $output);
+        $this->assertStringContainsString("Dto::create('Order')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildXml(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string'],
+            'age' => ['type' => 'int'],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'xml']);
+
+        $this->assertStringContainsString('<dto name="User">', $output);
+        $this->assertStringContainsString('name="name" type="string"', $output);
+        $this->assertStringContainsString('name="age" type="int"', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildXmlWithRequired(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string', 'required' => true],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'xml']);
+
+        $this->assertStringContainsString('required="true"', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildXmlWithAssociative(): void
+    {
+        $fields = [
+            'items' => ['type' => 'Item[]', 'associative' => 'id'],
+        ];
+
+        $output = $this->builder->build('Order', $fields, ['format' => 'xml']);
+
+        $this->assertStringContainsString('associative="true"', $output);
+        $this->assertStringContainsString('key="id"', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildAllXml(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $output = $this->builder->buildAll($definitions, ['format' => 'xml']);
+
+        $this->assertStringContainsString('<?xml version="1.0"', $output);
+        $this->assertStringContainsString('<dtos xmlns=', $output);
+        $this->assertStringContainsString('<dto name="User">', $output);
+        $this->assertStringContainsString('</dtos>', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildYaml(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string'],
+            'age' => ['type' => 'int'],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'yaml']);
+
+        $this->assertStringContainsString('User:', $output);
+        $this->assertStringContainsString('fields:', $output);
+        $this->assertStringContainsString('name:', $output);
+        $this->assertStringContainsString('type: string', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildYamlWithRequired(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string', 'required' => true],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'yaml']);
+
+        $this->assertStringContainsString('required: true', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildNeon(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string'],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'neon']);
+
+        // NEON is similar to YAML
+        $this->assertStringContainsString('User:', $output);
+        $this->assertStringContainsString('type: string', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhpDtoType(): void
+    {
+        $fields = [
+            'address' => ['type' => 'Address'],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::dto('Address')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhpDtoCollectionType(): void
+    {
+        $fields = [
+            'items' => ['type' => 'Item[]'],
+        ];
+
+        $output = $this->builder->build('Order', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::dtos('Item')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildPhpScalarCollections(): void
+    {
+        $fields = [
+            'tags' => ['type' => 'string[]'],
+            'counts' => ['type' => 'int[]'],
+        ];
+
+        $output = $this->builder->build('Item', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString('Field::strings', $output);
+        $this->assertStringContainsString('Field::ints', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildAllExcludesMarkedDefinitions(): void
+    {
+        $definitions = [
+            'Include' => [
+                'name' => ['type' => 'string'],
+            ],
+            'Exclude' => [
+                '_include' => false,
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $output = $this->builder->buildAll($definitions, ['format' => 'php']);
+
+        $this->assertStringContainsString("Dto::create('Include')", $output);
+        $this->assertStringNotContainsString("Dto::create('Exclude')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildExcludesMarkedFields(): void
+    {
+        $fields = [
+            'include' => ['type' => 'string'],
+            'exclude' => ['type' => 'string', '_include' => false],
+        ];
+
+        $output = $this->builder->build('User', $fields, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::string('include')", $output);
+        $this->assertStringNotContainsString('exclude', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildXmlEscapesSpecialCharacters(): void
+    {
+        $fields = [
+            'data' => ['type' => 'string<int>'],
+        ];
+
+        $output = $this->builder->build('Test', $fields, ['format' => 'xml']);
+
+        $this->assertStringContainsString('type="string&lt;int&gt;"', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDefaultFormatIsPhp(): void
+    {
+        $fields = [
+            'name' => ['type' => 'string'],
+        ];
+
+        $output = $this->builder->build('User', $fields);
+
+        $this->assertStringContainsString("Field::string('name')", $output);
+    }
+}

--- a/tests/Importer/ImporterTest.php
+++ b/tests/Importer/ImporterTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Importer;
+
+use PhpCollective\Dto\Importer\Importer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the main Importer class.
+ */
+class ImporterTest extends TestCase
+{
+    protected Importer $importer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importer = new Importer();
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseSimpleJsonData(): void
+    {
+        $json = '{"name": "John", "age": 30, "active": true}';
+        $result = $this->importer->parse($json);
+
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayHasKey('name', $result['Object']);
+        $this->assertArrayHasKey('age', $result['Object']);
+        $this->assertArrayHasKey('active', $result['Object']);
+
+        $this->assertSame('string', $result['Object']['name']['type']);
+        $this->assertSame('int', $result['Object']['age']['type']);
+        $this->assertSame('bool', $result['Object']['active']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNestedJsonData(): void
+    {
+        $json = '{"name": "John", "address": {"city": "NYC", "zip": "10001"}}';
+        $result = $this->importer->parse($json);
+
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayHasKey('Address', $result);
+
+        $this->assertSame('Address', $result['Object']['address']['type']);
+        $this->assertSame('string', $result['Address']['city']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseCollectionData(): void
+    {
+        $json = '{"users": [{"name": "John"}, {"name": "Jane"}]}';
+        $result = $this->importer->parse($json);
+
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayHasKey('User', $result);
+
+        $this->assertSame('User[]', $result['Object']['users']['type']);
+        $this->assertSame('user', $result['Object']['users']['singular']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseJsonSchema(): void
+    {
+        $schema = json_encode([
+            'type' => 'object',
+            'title' => 'User',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'age' => ['type' => 'integer'],
+            ],
+            'required' => ['name'],
+        ]);
+
+        $result = $this->importer->parse($schema);
+
+        $this->assertArrayHasKey('User', $result);
+        $this->assertTrue($result['User']['name']['required']);
+        $this->assertFalse($result['User']['age']['required']);
+        $this->assertSame('string', $result['User']['name']['type']);
+        $this->assertSame('int', $result['User']['age']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseWithNamespace(): void
+    {
+        $json = '{"name": "John"}';
+        $result = $this->importer->parse($json, ['namespace' => 'Api/Response']);
+
+        $this->assertArrayHasKey('Api/Response/Object', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseArray(): void
+    {
+        $data = ['name' => 'John', 'age' => 30];
+        $result = $this->importer->parseArray($data);
+
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertSame('string', $result['Object']['name']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildSchemaPhp(): void
+    {
+        $json = '{"name": "John", "age": 30}';
+        $definitions = $this->importer->parse($json);
+        $output = $this->importer->buildSchema($definitions, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::string('name')", $output);
+        $this->assertStringContainsString("Field::int('age')", $output);
+        $this->assertStringContainsString("Dto::create('Object')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildSchemaXml(): void
+    {
+        $json = '{"name": "John", "age": 30}';
+        $definitions = $this->importer->parse($json);
+        $output = $this->importer->buildSchema($definitions, ['format' => 'xml']);
+
+        $this->assertStringContainsString('<dto name="Object">', $output);
+        $this->assertStringContainsString('name="name" type="string"', $output);
+        $this->assertStringContainsString('name="age" type="int"', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildSchemaYaml(): void
+    {
+        $json = '{"name": "John", "age": 30}';
+        $definitions = $this->importer->parse($json);
+        $output = $this->importer->buildSchema($definitions, ['format' => 'yaml']);
+
+        $this->assertStringContainsString('Object:', $output);
+        $this->assertStringContainsString('name:', $output);
+        $this->assertStringContainsString('type: string', $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testImportConvenienceMethod(): void
+    {
+        $json = '{"name": "John"}';
+        $output = $this->importer->import($json, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::string('name')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testImportArrayConvenienceMethod(): void
+    {
+        $data = ['name' => 'John'];
+        $output = $this->importer->importArray($data, ['format' => 'php']);
+
+        $this->assertStringContainsString("Field::string('name')", $output);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseEmptyJson(): void
+    {
+        $result = $this->importer->parse('{}');
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNullValue(): void
+    {
+        $json = '{"value": null}';
+        $result = $this->importer->parse($json);
+
+        $this->assertSame('mixed', $result['Object']['value']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseFloatValue(): void
+    {
+        $json = '{"price": 19.99}';
+        $result = $this->importer->parse($json);
+
+        $this->assertSame('float', $result['Object']['price']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAutoDetectJsonSchema(): void
+    {
+        // This should be auto-detected as JSON Schema
+        $schema = json_encode([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer'],
+            ],
+        ]);
+
+        $result = $this->importer->parse($schema);
+
+        // Schema parser marks required explicitly
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayHasKey('required', $result['Object']['id']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAutoDetectDataJson(): void
+    {
+        // This should be auto-detected as plain data
+        $json = '{"id": 123, "type": "user"}';
+        $result = $this->importer->parse($json);
+
+        // Data parser doesn't have required field
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayNotHasKey('required', $result['Object']['id']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSkipUnderscoreFields(): void
+    {
+        $json = '{"name": "John", "_internal": "secret"}';
+        $result = $this->importer->parse($json);
+
+        $this->assertArrayHasKey('name', $result['Object']);
+        $this->assertArrayNotHasKey('_internal', $result['Object']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFieldNameNormalization(): void
+    {
+        $json = '{"first_name": "John", "last-name": "Doe", "UserEmail": "john@example.com"}';
+        $result = $this->importer->parse($json);
+
+        $this->assertArrayHasKey('firstName', $result['Object']);
+        $this->assertArrayHasKey('lastName', $result['Object']);
+        $this->assertArrayHasKey('userEmail', $result['Object']);
+    }
+}

--- a/tests/Importer/Parser/DataParserTest.php
+++ b/tests/Importer/Parser/DataParserTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Importer\Parser;
+
+use PhpCollective\Dto\Importer\Parser\DataParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for DataParser.
+ */
+class DataParserTest extends TestCase
+{
+    protected DataParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new DataParser();
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseName(): void
+    {
+        $this->assertSame('Data', DataParser::NAME);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseScalarTypes(): void
+    {
+        $data = [
+            'string' => 'hello',
+            'int' => 42,
+            'float' => 3.14,
+            'bool' => true,
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertSame('string', $result['Object']['string']['type']);
+        $this->assertSame('int', $result['Object']['int']['type']);
+        $this->assertSame('float', $result['Object']['float']['type']);
+        $this->assertSame('bool', $result['Object']['bool']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNestedObject(): void
+    {
+        $data = [
+            'user' => [
+                'name' => 'John',
+                'email' => 'john@example.com',
+            ],
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayHasKey('User', $result);
+        $this->assertSame('User', $result['Object']['user']['type']);
+        $this->assertSame('string', $result['User']['name']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseCollection(): void
+    {
+        $data = [
+            'items' => [
+                ['id' => 1, 'name' => 'Item 1'],
+                ['id' => 2, 'name' => 'Item 2'],
+            ],
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertSame('Item[]', $result['Object']['items']['type']);
+        $this->assertSame('item', $result['Object']['items']['singular']);
+        $this->assertSame('string', $result['Item']['name']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDetectAssociativeKey(): void
+    {
+        $data = [
+            'users' => [
+                ['slug' => 'john', 'name' => 'John'],
+                ['slug' => 'jane', 'name' => 'Jane'],
+            ],
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertSame('slug', $result['Object']['users']['associative']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseWithNamespace(): void
+    {
+        $data = ['name' => 'John'];
+
+        $result = $this->parser->parse($data, ['namespace' => 'App/Dto'])->result();
+
+        $this->assertArrayHasKey('App/Dto/Object', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNestedWithNamespace(): void
+    {
+        $data = [
+            'address' => [
+                'city' => 'NYC',
+            ],
+        ];
+
+        $result = $this->parser->parse($data, ['namespace' => 'App'])->result();
+
+        $this->assertArrayHasKey('App/Object', $result);
+        $this->assertArrayHasKey('App/Address', $result);
+        $this->assertSame('App/Address', $result['App/Object']['address']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSkipPrivateFields(): void
+    {
+        $data = [
+            'name' => 'John',
+            '_private' => 'secret',
+            '__meta' => 'hidden',
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertArrayHasKey('name', $result['Object']);
+        $this->assertArrayNotHasKey('_private', $result['Object']);
+        $this->assertArrayNotHasKey('__meta', $result['Object']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testNullValueType(): void
+    {
+        $data = ['value' => null];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertSame('mixed', $result['Object']['value']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSimpleArrayNotTreatedAsCollection(): void
+    {
+        $data = [
+            'tags' => ['php', 'dto', 'generator'],
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        // Simple string array should be 'array', not a collection
+        $this->assertSame('array', $result['Object']['tags']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeepNesting(): void
+    {
+        $data = [
+            'level1' => [
+                'level2' => [
+                    'level3' => [
+                        'value' => 'deep',
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->parser->parse($data)->result();
+
+        $this->assertArrayHasKey('Object', $result);
+        $this->assertArrayHasKey('Level1', $result);
+        $this->assertArrayHasKey('Level2', $result);
+        $this->assertArrayHasKey('Level3', $result);
+    }
+}

--- a/tests/Importer/Parser/SchemaParserTest.php
+++ b/tests/Importer/Parser/SchemaParserTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Importer\Parser;
+
+use PhpCollective\Dto\Importer\Parser\SchemaParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for SchemaParser.
+ */
+class SchemaParserTest extends TestCase
+{
+    protected SchemaParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new SchemaParser();
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseName(): void
+    {
+        $this->assertSame('Schema', SchemaParser::NAME);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseBasicSchema(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'age' => ['type' => 'integer'],
+                'active' => ['type' => 'boolean'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('string', $result['Object']['name']['type']);
+        $this->assertSame('int', $result['Object']['age']['type']);
+        $this->assertSame('bool', $result['Object']['active']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseWithTitle(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'title' => 'User Profile',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertArrayHasKey('UserProfile', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseRequiredFields(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer'],
+                'name' => ['type' => 'string'],
+            ],
+            'required' => ['id'],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertTrue($result['Object']['id']['required']);
+        $this->assertFalse($result['Object']['name']['required']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNestedObject(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'city' => ['type' => 'string'],
+                        'zip' => ['type' => 'string'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('Address', $result['Object']['address']['type']);
+        $this->assertSame('string', $result['Address']['city']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseArrayOfObjects(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'items' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'id' => ['type' => 'integer'],
+                            'name' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('Item[]', $result['Object']['items']['type']);
+        $this->assertArrayHasKey('Item', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNullableType(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'value' => ['type' => ['string', 'null']],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('string', $result['Object']['value']['type']);
+        $this->assertFalse($result['Object']['value']['required']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseAnyOf(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'data' => [
+                    'anyOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'null'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('string', $result['Object']['data']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseOneOf(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'data' => [
+                    'oneOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('string|int', $result['Object']['data']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseEnum(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'status' => [
+                    'enum' => ['active', 'inactive', 'pending'],
+                ],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('string', $result['Object']['status']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseNumberType(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'price' => ['type' => 'number'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('float', $result['Object']['price']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSkipRefProperties(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'related' => ['$ref' => '#/definitions/Other'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertArrayHasKey('name', $result['Object']);
+        $this->assertArrayNotHasKey('related', $result['Object']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseWithNamespace(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema, ['namespace' => 'Api/V1'])->result();
+
+        $this->assertArrayHasKey('Api/V1/Object', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseEmptySchema(): void
+    {
+        $result = $this->parser->parse([])->result();
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseSchemaWithoutProperties(): void
+    {
+        $schema = ['type' => 'object'];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseMixedType(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'data' => [],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('mixed', $result['Object']['data']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSkipUnderscoreProperties(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                '_internal' => ['type' => 'string'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertArrayHasKey('name', $result['Object']);
+        $this->assertArrayNotHasKey('_internal', $result['Object']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new Importer utility that generates DTO configuration from JSON data or JSON Schema definitions. This is a scaffolding tool to help quickly bootstrap DTO configs when integrating with external APIs or migrating from other systems.

### Features

- **Auto-detection**: Automatically detects whether input is JSON data or JSON Schema
- **Multiple input types**:
  - JSON data examples (infers types from values)
  - JSON Schema definitions (uses schema type information, respects `required` array)
- **Multiple output formats**: PHP, XML, YAML, NEON
- **Smart inference**:
  - Detects nested objects and creates separate DTOs
  - Detects collections (arrays of objects)
  - Auto-detects potential associative array keys (slug, name, id)
  - Normalizes field names to camelCase
- **Configurable namespace prefix**

### Usage

```php
use PhpCollective\Dto\Importer\Importer;

$importer = new Importer();

// From JSON data
$json = '{"name": "John", "age": 30}';
echo $importer->import($json);

// From JSON Schema
$schema = file_get_contents('schema.json');
echo $importer->import($schema, ['format' => 'xml']);

// With namespace prefix
echo $importer->import($json, ['namespace' => 'Api/Response']);
```

### Components

| Component | Purpose |
|-----------|---------|
| `Importer` | Main entry point with `parse()`, `import()` methods |
| `DataParser` | Infers types from JSON data examples |
| `SchemaParser` | Parses JSON Schema definitions |
| `SchemaBuilder` | Generates config in PHP/XML/YAML/NEON formats |
| `ParserFactory` | Creates parser instances by type |

### Limitations

The importer is a scaffolding tool. Generated configs typically need manual refinement:
- No enum detection (imported as `string`)
- No custom type detection (DateTime, etc.)
- Limited validation (only `required` from JSON Schema)
- Type inference is based on example data

## Test plan

- [x] Unit tests for DataParser (scalar types, nested objects, collections)
- [x] Unit tests for SchemaParser (basic types, required fields, anyOf/oneOf)
- [x] Unit tests for SchemaBuilder (all output formats)
- [x] Integration tests for Importer (auto-detection, convenience methods)
- [x] 65 tests total, all passing