### PR TITLE
Fix array union types and shell command escaping

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -844,6 +844,14 @@ class Builder
         if ($this->isValidSimpleType($type)) {
             $types = explode('|', $type);
             if (count($types) > 1) {
+                // PHP doesn't support array notation in union types (e.g., string[]|int[] is invalid)
+                // Convert to 'array' if any part uses array notation
+                foreach ($types as $t) {
+                    if (str_ends_with($t, '[]')) {
+                        return 'array';
+                    }
+                }
+
                 // Return union type
                 return $type;
             }

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -202,7 +202,7 @@ class Generator
      */
     protected function checkPhpFileSyntax(string $file): bool
     {
-        exec('php -l "' . $file . '"', $output, $returnValue);
+        exec('php -l ' . escapeshellarg($file), $output, $returnValue);
 
         if ($returnValue !== static::CODE_SUCCESS) {
             $this->io->error('PHP file invalid: ' . implode("\n", $output));


### PR DESCRIPTION
## Summary

Fixes two issues:

### 1. Array union types generate invalid PHP (BUG)

**Before:** Config like `type: string[]|int[]` would generate invalid PHP:
```php
public function getData(): ?string[]|int[] { ... }
```

**After:** Converts to valid `array` type hint:
```php
public function getData(): ?array { ... }
```

PHP doesn't support array notation (`[]`) in union type hints. The `typehint()` method now detects union types containing array notation and returns `array` instead. The original type is preserved in PHPDoc for IDE support.

### 2. Shell command escaping

**Before:**
```php
exec('php -l "' . $file . '"', $output, $returnValue);
```

**After:**
```php
exec('php -l ' . escapeshellarg($file), $output, $returnValue);
```

Uses `escapeshellarg()` for proper escaping of file paths with special characters. This follows security best practices.

## Test plan

- [x] Added `testArrayUnionTypesConvertToArray` - verifies `string[]|int[]` converts to `array`
- [x] Added `testMixedArrayAndScalarUnionTypesConvertToArray` - verifies `string[]|int` converts to `array`
- [x] All existing tests pass (399 tests)