### PR TITLE
Fix isCustomCollectionType() bug and add cloneTraversable tests

### DIFF
--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -457,7 +457,8 @@ abstract class Dto implements Serializable
     protected function isCustomCollectionType(string $collectionType): bool
     {
         // CakePHP Collection or any custom Traversable that's not ArrayObject
-        return $collectionType !== '\ArrayObject' && !is_subclass_of($collectionType, ArrayObject::class);
+        // is_a() with third param true checks if class is same or subclass
+        return !is_a($collectionType, ArrayObject::class, true);
     }
 
     /**

--- a/tests/TestDto/TraversableDto.php
+++ b/tests/TestDto/TraversableDto.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\TestDto;
+
+use PhpCollective\Dto\Dto\AbstractDto;
+use Traversable;
+
+/**
+ * A DTO with a loosely-typed Traversable field for testing custom collection cloning.
+ */
+class TraversableDto extends AbstractDto
+{
+    /**
+     * @var \Traversable<int, \PhpCollective\Dto\Test\TestDto\SimpleDto>|null
+     */
+    protected ?Traversable $items = null;
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $_metadata = [
+        'items' => [
+            'type' => SimpleDto::class,
+            'required' => false,
+            'defaultValue' => null,
+            'dto' => false,
+            'collectionType' => 'Traversable',
+            'singularType' => SimpleDto::class,
+            'associative' => false,
+            'key' => null,
+            'serialize' => null,
+            'factory' => null,
+            'isClass' => false,
+            'enum' => null,
+        ],
+    ];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    protected array $_keyMap = [
+        'underscored' => [
+            'items' => 'items',
+        ],
+        'dashed' => [
+            'items' => 'items',
+        ],
+    ];
+
+    /**
+     * @return \Traversable<int, \PhpCollective\Dto\Test\TestDto\SimpleDto>|null
+     */
+    public function getItems(): ?Traversable
+    {
+        return $this->items;
+    }
+
+    /**
+     * @param \Traversable<int, \PhpCollective\Dto\Test\TestDto\SimpleDto>|null $items
+     *
+     * @return $this
+     */
+    public function setItems(?Traversable $items)
+    {
+        $this->items = $items;
+        $this->_touchedFields['items'] = true;
+
+        return $this;
+    }
+
+    public function hasItems(): bool
+    {
+        return $this->items !== null;
+    }
+}


### PR DESCRIPTION
## Summary
- Fix bug in `isCustomCollectionType()` where string comparison `'ArrayObject' !== '\ArrayObject'` always returned true
- Use `is_a()` with allow_string=true for proper class identity checking
- Add `TraversableDto` test fixture with loose `Traversable` typing to enable testing of `cloneTraversable()`
- Add comprehensive tests covering all `cloneTraversable()` code paths

## Bug Details
The previous implementation compared `$collectionType !== 'ArrayObject'` but the actual collection type stored was `\ArrayObject` (with leading backslash), so custom collection factory was never actually called.

## Tests Added
- `testCloneTraversableWithCustomIterator` - Tests cloning with ArrayIterator containing DTOs
- `testCloneTraversableUsesCollectionFactory` - Verifies factory is called during clone
- `testCloneTraversableWithoutFactoryReturnsArrayObject` - Fallback behavior without factory
- `testCloneTraversableWithPlainObjects` - Non-DTO objects are also cloned
- `testCloneTraversableWithScalarValues` - Scalar values handled correctly
- `testCustomCollectionFactoryNotCalledForArrayObject` - Factory bypass for ArrayObject types
- `testAbstractDtoUnserializeModifiesSelf` - Verifies AbstractDto unserialize behavior