### PR TITLE
Proposal: Shaped array type generation

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -232,6 +232,11 @@ class Builder
             $config[$name] = $dto;
         }
 
+        // Add shaped array types for toArray()/createFromArray() PHPDoc
+        foreach ($config as $name => $dto) {
+            $config[$name]['arrayShape'] = $this->buildArrayShape($dto['fields'], $config);
+        }
+
         return $config;
     }
 
@@ -943,6 +948,95 @@ class Builder
         $keyType = $field['associative'] ? 'string' : 'int';
 
         return sprintf('%s<%s, %s>', $collectionType, $keyType, $elementType);
+    }
+
+    /**
+     * Build a shaped array type for PHPDoc annotations on toArray()/createFromArray().
+     *
+     * Generates types like: array{name: string, count: int, items: array<int, ItemDto>}
+     *
+     * @param array<string, array<string, mixed>> $fields
+     * @param array<string, array<string, mixed>> $allDtos All DTOs for resolving nested shapes
+     *
+     * @return string
+     */
+    protected function buildArrayShape(array $fields, array $allDtos = []): string
+    {
+        $parts = [];
+
+        foreach ($fields as $name => $field) {
+            $type = $this->buildFieldShapeType($field, $allDtos);
+            $parts[] = $name . ': ' . $type;
+        }
+
+        return 'array{' . implode(', ', $parts) . '}';
+    }
+
+    /**
+     * Build the shaped array type for a single field.
+     *
+     * @param array<string, mixed> $field
+     * @param array<string, array<string, mixed>> $allDtos
+     *
+     * @return string
+     */
+    protected function buildFieldShapeType(array $field, array $allDtos = []): string
+    {
+        // For collections, use array<keyType, elementType>
+        if (!empty($field['collection']) || !empty($field['isArray'])) {
+            $elementType = $field['singularType'] ?? 'mixed';
+            $keyType = !empty($field['associative']) ? 'string' : 'int';
+
+            // If element is a DTO, try to resolve its shape
+            $dtoName = $this->extractDtoName($elementType);
+            if ($dtoName && isset($allDtos[$dtoName])) {
+                $nestedShape = $this->buildArrayShape($allDtos[$dtoName]['fields'], $allDtos);
+                $elementType = $nestedShape;
+            }
+
+            $type = sprintf('array<%s, %s>', $keyType, $elementType);
+        } elseif (!empty($field['dto'])) {
+            // For nested DTOs, build nested shape if available
+            $dtoName = $this->extractDtoName($field['type']);
+            if ($dtoName && isset($allDtos[$dtoName])) {
+                $type = $this->buildArrayShape($allDtos[$dtoName]['fields'], $allDtos);
+            } else {
+                $type = 'array<string, mixed>';
+            }
+        } else {
+            // Simple type
+            $type = $field['typeHint'] ?? $field['type'] ?? 'mixed';
+        }
+
+        // Add null if nullable
+        if (!empty($field['nullable'])) {
+            $type .= '|null';
+        }
+
+        return $type;
+    }
+
+    /**
+     * Extract the DTO name from a fully qualified class name.
+     *
+     * @param string $type
+     *
+     * @return string|null
+     */
+    protected function extractDtoName(string $type): ?string
+    {
+        // Remove leading backslash and namespace, extract class name without Dto suffix
+        $className = ltrim($type, '\\');
+        $parts = explode('\\', $className);
+        $shortName = end($parts);
+
+        // Remove Dto suffix if present
+        $suffix = $this->getConfigOrFail('suffix');
+        if (str_ends_with($shortName, $suffix)) {
+            return substr($shortName, 0, -strlen($suffix));
+        }
+
+        return $shortName;
     }
 
     /**

--- a/templates/dto.twig
+++ b/templates/dto.twig
@@ -34,4 +34,5 @@ class {{ className }} extends {% if extends starts with '\\' %}{{ extends[1:] | 
 {% include 'element/map.twig' with {'fields': fields} only %}
 {% include 'element/optimizations.twig' with {'fields': fields, 'immutable': immutable} only %}
 {% include 'element/methods.twig' with {'fields': fields, 'immutable': immutable} only -%}
+{% include 'element/array_shape.twig' with {'arrayShape': arrayShape} only %}
 }

--- a/templates/element/array_shape.twig
+++ b/templates/element/array_shape.twig
@@ -1,0 +1,26 @@
+
+	/**
+	 * @param string|null $type
+	 * @param array<string>|null $fields
+	 * @param bool $touched
+	 *
+	 * @return {{ arrayShape }}
+	 */
+	#[\Override]
+	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array
+	{
+		return parent::toArray($type, $fields, $touched);
+	}
+
+	/**
+	 * @param {{ arrayShape }} $data
+	 * @param bool $ignoreMissing
+	 * @param string|null $type
+	 *
+	 * @return static
+	 */
+	#[\Override]
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static
+	{
+		return parent::createFromArray($data, $ignoreMissing, $type);
+	}

--- a/tests/Generator/ShapedArrayTest.php
+++ b/tests/Generator/ShapedArrayTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Engine\PhpEngine;
+use PhpCollective\Dto\Generator\ArrayConfig;
+use PhpCollective\Dto\Generator\Builder;
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\Generator;
+use PhpCollective\Dto\Generator\IoInterface;
+use PhpCollective\Dto\Generator\TwigRenderer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for shaped array type generation on toArray()/createFromArray().
+ */
+class ShapedArrayTest extends TestCase
+{
+    protected string $tempDir;
+
+    /**
+     * @var resource
+     */
+    protected $stdout;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/shaped_array_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        mkdir($this->tempDir . '/config', 0777, true);
+        $this->stdout = fopen('php://memory', 'r+');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+        fclose($this->stdout);
+    }
+
+    protected function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    protected function createIo(): ConsoleIo
+    {
+        return new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stdout);
+    }
+
+    public function testBuilderGeneratesArrayShape(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'User' => [
+        'fields' => [
+            'id' => 'int',
+            'name' => 'string',
+            'active' => 'bool',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        // Should have arrayShape at the DTO level
+        $this->assertArrayHasKey('arrayShape', $definitions['User']);
+        $this->assertSame('array{id: int|null, name: string|null, active: bool|null}', $definitions['User']['arrayShape']);
+    }
+
+    public function testBuilderGeneratesArrayShapeWithNestedDto(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Order' => [
+        'fields' => [
+            'id' => 'int',
+            'customer' => 'Customer',
+        ],
+    ],
+    'Customer' => [
+        'fields' => [
+            'name' => 'string',
+            'email' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        // Order should have nested shape for Customer
+        $this->assertArrayHasKey('arrayShape', $definitions['Order']);
+        $this->assertStringContainsString('customer: array{name: string|null, email: string|null}', $definitions['Order']['arrayShape']);
+    }
+
+    public function testBuilderGeneratesArrayShapeWithCollection(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Order' => [
+        'fields' => [
+            'id' => 'int',
+            'items' => [
+                'type' => 'Item[]',
+                'collection' => true,
+                'singular' => 'item',
+            ],
+        ],
+    ],
+    'Item' => [
+        'fields' => [
+            'name' => 'string',
+            'price' => 'float',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'App']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+
+        $definitions = $builder->build($this->tempDir . '/config/');
+
+        // Order should have array type for items collection
+        $this->assertArrayHasKey('arrayShape', $definitions['Order']);
+        $this->assertStringContainsString('items: array<int, array{name: string|null, price: float|null}>', $definitions['Order']['arrayShape']);
+    }
+
+    public function testGeneratedDtoHasShapedArrayMethods(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'User' => [
+        'fields' => [
+            'id' => [
+                'type' => 'int',
+                'required' => true,
+            ],
+            'name' => 'string',
+            'email' => 'string',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'TestApp']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+        $renderer = new TwigRenderer(null, $config);
+
+        $generator = new Generator($builder, $renderer, $this->createIo(), $config);
+        $generator->generate($this->tempDir . '/config/', $this->tempDir . '/src/');
+
+        $generatedFile = $this->tempDir . '/src/Dto/UserDto.php';
+        $this->assertFileExists($generatedFile);
+
+        $content = file_get_contents($generatedFile);
+        $this->assertIsString($content);
+
+        // Should have overridden toArray with shaped array return type
+        $this->assertStringContainsString('@return array{id: int, name: string|null, email: string|null}', $content);
+        $this->assertStringContainsString('#[\Override]', $content);
+        $this->assertStringContainsString('public function toArray(', $content);
+
+        // Should have overridden createFromArray with shaped array param type
+        $this->assertStringContainsString('@param array{id: int, name: string|null, email: string|null} $data', $content);
+        $this->assertStringContainsString('public static function createFromArray(', $content);
+    }
+
+    public function testGeneratedDtoWithNestedShapedArrays(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+return [
+    'Order' => [
+        'fields' => [
+            'id' => 'int',
+            'customer' => 'Customer',
+            'items' => [
+                'type' => 'Item[]',
+                'collection' => true,
+                'collectionType' => 'array',
+                'singular' => 'item',
+            ],
+        ],
+    ],
+    'Customer' => [
+        'fields' => [
+            'name' => 'string',
+        ],
+    ],
+    'Item' => [
+        'fields' => [
+            'name' => 'string',
+            'price' => 'float',
+        ],
+    ],
+];
+PHP;
+        file_put_contents($this->tempDir . '/config/dto.php', $configContent);
+
+        $config = new ArrayConfig(['namespace' => 'TestApp']);
+        $engine = new PhpEngine();
+        $builder = new Builder($engine, $config);
+        $renderer = new TwigRenderer(null, $config);
+
+        $generator = new Generator($builder, $renderer, $this->createIo(), $config);
+        $generator->generate($this->tempDir . '/config/', $this->tempDir . '/src/');
+
+        $generatedFile = $this->tempDir . '/src/Dto/OrderDto.php';
+        $this->assertFileExists($generatedFile);
+
+        $content = file_get_contents($generatedFile);
+        $this->assertIsString($content);
+
+        // Should have nested shapes
+        $this->assertStringContainsString('customer: array{name: string|null}', $content);
+        $this->assertStringContainsString('items: array<int, array{name: string|null, price: float|null}>', $content);
+    }
+}


### PR DESCRIPTION
## Summary

- Proposes generating PHPStan/Psalm shaped array annotations for `toArray()` and `createFromArray()` methods
- Would enable full static analysis support for array structures returned by DTOs
- Addresses the "Shaped Arrays" gap compared to valinor (though different approach - output types vs input mapping)

## Proposed Feature

Instead of:
```php
/** @return array */
public function toArray(): array
```

Generate:
```php
/** @return array{name: ?string, count: ?int, active: ?bool} */
public function toArray(): array
```

## Benefits

- IDE autocomplete on `$dto->toArray()['key']`
- Typo detection for array keys
- Type inference when destructuring arrays
- Strengthens "Excellent static analysis" positioning

See `docs/ShapedArrayTypes.md` for full proposal details.