### PR TITLE
Add @var type assertion for PHPStan shaped array return type

### DIFF
--- a/templates/element/array_shape.twig
+++ b/templates/element/array_shape.twig
@@ -8,7 +8,10 @@
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array
 	{
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var {{ arrayShape }} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds `@var` type assertion in `toArray()` method template to fix PHPStan `return.type` error
- The `_toArrayInternal()` returns `array<string, mixed>` but generated DTOs declare shaped array return types
- This inline assertion tells PHPStan the expected type without changing runtime behavior

## Test plan
- [x] Tests pass (`vendor/bin/phpunit`)
- [x] PHPCS passes (`vendor/bin/phpcs`)
- [x] Generated DTOs now include `@var` assertion for shaped array types