### PR TITLE
Use specific key type for associative collection methods

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -589,6 +589,9 @@ class Builder
                         }
                     }
                 }
+
+                // Add key type for associative collections (string) vs indexed (int)
+                $fields[$key]['keyType'] = !empty($fields[$key]['associative']) ? 'string' : 'int';
             }
         }
 

--- a/templates/element/method_add.twig
+++ b/templates/element/method_add.twig
@@ -5,7 +5,7 @@
 	 *
 {% endif %}
 {% if associative %}
-	 * @param string|int $key
+	 * @param {{ keyType }} $key
 {% endif %}
 	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return $this

--- a/templates/element/method_get.twig
+++ b/templates/element/method_get.twig
@@ -24,7 +24,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param string|int $key
+	 * @param {{ keyType }} $key
 	 *
 	 * @return {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %}
 

--- a/templates/element/method_has.twig
+++ b/templates/element/method_has.twig
@@ -30,7 +30,7 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param string|int $key
+	 * @param {{ keyType }} $key
 	 * @return bool
 	 */
 	public function has{{ singular[:1]|upper ~ singular[1:] }}($key){% if scalarAndReturnTypes %}: bool{% endif %}

--- a/templates/element/method_with_added.twig
+++ b/templates/element/method_with_added.twig
@@ -5,7 +5,7 @@
 	 *
 {% endif %}
 {% if associative %}
-	 * @param string|int $key
+	 * @param {{ keyType }} $key
 {% endif %}
 	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static


### PR DESCRIPTION
## Summary

For associative collections, use `@param string $key` instead of hardcoded `@param string|int $key`. This makes PHPStan analysis more accurate when using `array<string, T>` typed properties.

- Add `keyType` field to collection field data (`string` for associative, `int` for indexed)
- Update method_add.twig, method_with_added.twig, method_get.twig, method_has.twig
- Add test for keyType in GenericPhpDocTest

## Problem

When using shaped array types with PHPStan (level 8+), the generated `add*` and `withAdded*` methods for associative collections would cause `assign.propertyType` errors because:

- Property is typed as `array<string, ItemDto>`
- But `add*` method has `@param string|int $key` allowing int keys

This creates a type mismatch that PHPStan correctly identifies.

## Solution

Instead of hardcoding `string|int` for all key parameters, calculate the actual key type:
- For `associative: true` collections → `string`
- For indexed collections → `int`

This ensures the PHPDoc matches the actual property type annotation.