### PR TITLE
Fix fast path condition to use lenient mode

### DIFF
--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -232,8 +232,9 @@ abstract class Dto implements Serializable
     public function __construct(?array $data = null, bool $ignoreMissing = false, ?string $type = null)
     {
         if ($data) {
-            // Use optimized fast path when available (no special type, no ignoreMissing)
-            if (!$ignoreMissing && $type === null && method_exists($this, 'setFromArrayFast')) {
+            // Use optimized fast path only in lenient mode (ignoreMissing=true)
+            // Strict mode needs full type validation via setFromArray
+            if ($ignoreMissing && $type === null && method_exists($this, 'setFromArrayFast')) {
                 $this->setFromArrayFast($data);
             } else {
                 $this->setFromArray($data, $ignoreMissing, $type);


### PR DESCRIPTION
## Summary

Fix the fast path condition in the constructor to use lenient mode (`ignoreMissing=true`) instead of strict mode.

## Problem

The `setFromArrayFast` method skips type validation for performance. However, the condition `!$ignoreMissing` meant it was being used in **strict mode** (when `ignoreMissing=false`), which caused type validation to be bypassed when it shouldn't be.

## Solution

Change the condition from `!$ignoreMissing` to `$ignoreMissing` so the fast path is only used in lenient mode where validation is intentionally relaxed.

## Test plan

- [x] All 431 tests pass