### PR TITLE
Fix default value rendering in generated DTOs

### DIFF
--- a/src/Generator/TwigRenderer.php
+++ b/src/Generator/TwigRenderer.php
@@ -58,6 +58,7 @@ class TwigRenderer implements RendererInterface
     protected function registerFilters(): void
     {
         $this->twig->addFilter(new TwigFilter('stringify', [$this, 'stringifyList']));
+        $this->twig->addFilter(new TwigFilter('phpExport', [$this, 'phpExport']));
         $this->twig->addFilter(new TwigFilter('underscore', [Inflector::class, 'underscore']));
         $this->twig->addFilter(new TwigFilter('camelize', [Inflector::class, 'camelize']));
         $this->twig->addFilter(new TwigFilter('variable', [Inflector::class, 'variable']));
@@ -164,5 +165,32 @@ class TwigRenderer implements RendererInterface
         }
 
         return $start . implode($join, $list) . $end;
+    }
+
+    /**
+     * Export a PHP value to its code representation.
+     *
+     * Handles booleans, strings, numbers, arrays, and null properly.
+     *
+     * @param mixed $value The value to export
+     *
+     * @return string
+     */
+    public function phpExport(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_string($value)) {
+            return "'" . addcslashes($value, "'\\") . "'";
+        }
+        if (is_array($value)) {
+            return var_export($value, true);
+        }
+
+        return (string)$value;
     }
 }

--- a/templates/element/optimizations.twig
+++ b/templates/element/optimizations.twig
@@ -84,7 +84,7 @@
 {% if fieldsWithDefaults | length > 0 %}
 {% for field in fieldsWithDefaults %}
 		if ($this->{{ field.name }} === null) {
-			$this->{{ field.name }} = {{ field.defaultValue | json_encode }};
+			$this->{{ field.name }} = {{ field.defaultValue | phpExport | raw }};
 		}
 {% endfor %}
 {% endif %}

--- a/templates/element/property.twig
+++ b/templates/element/property.twig
@@ -1,4 +1,4 @@
 	/**
 	 * @var {{ docBlockType ?? type }}{% if nullable %}|null{% endif ~%}
 	 */
-	protected {% if returnTypeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if nullable %} = null{% elseif defaultValue is defined and defaultValue is not null %} = {{ defaultValue }}{% endif %};
+	protected {% if returnTypeHint %}{% if collection and collectionType != 'array' %}?{{ typeHint }}{% else %}{{ nullableTypeHint ?? typeHint }}{% endif %} {% endif %}${{ name }}{% if nullable %} = null{% elseif defaultValue is defined and defaultValue is not null %} = {{ defaultValue | phpExport | raw }}{% elseif collection and collectionType != 'array' %} = null{% endif %};

--- a/tests/Generator/DefaultValueRenderingTest.php
+++ b/tests/Generator/DefaultValueRenderingTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Engine\XmlEngine;
+use PhpCollective\Dto\Generator\ArrayConfig;
+use PhpCollective\Dto\Generator\Builder;
+use PhpCollective\Dto\Generator\TwigRenderer;
+use PHPUnit\Framework\TestCase;
+
+class DefaultValueRenderingTest extends TestCase
+{
+    public function testBooleanDefaultValueRenderedAsTrue(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="BoolDefault">
+        <field name="enabled" type="bool" defaultValue="true"/>
+        <field name="disabled" type="bool" defaultValue="false"/>
+    </dto>
+</dtos>
+XML;
+
+        $code = $this->generateDtoCode($xml, 'BoolDefault');
+
+        // Property should have 'true' not '1'
+        $this->assertStringContainsString('$enabled = true;', $code);
+        $this->assertStringContainsString('$disabled = false;', $code);
+        $this->assertStringNotContainsString('$enabled = 1;', $code);
+        $this->assertStringNotContainsString('$disabled = 0;', $code);
+    }
+
+    public function testStringDefaultValueRenderedWithQuotes(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="StringDefault">
+        <field name="country" type="string" defaultValue="USA"/>
+        <field name="status" type="string" defaultValue="active"/>
+    </dto>
+</dtos>
+XML;
+
+        $code = $this->generateDtoCode($xml, 'StringDefault');
+
+        // Property should have quoted strings
+        $this->assertStringContainsString("\$country = 'USA';", $code);
+        $this->assertStringContainsString("\$status = 'active';", $code);
+    }
+
+    public function testIntegerDefaultValueRenderedWithoutQuotes(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="IntDefault">
+        <field name="count" type="int" defaultValue="10"/>
+        <field name="priority" type="int" defaultValue="0"/>
+    </dto>
+</dtos>
+XML;
+
+        $code = $this->generateDtoCode($xml, 'IntDefault');
+
+        // Property should have unquoted integers
+        $this->assertStringContainsString('$count = 10;', $code);
+        $this->assertStringContainsString('$priority = 0;', $code);
+    }
+
+    public function testFloatDefaultValueRenderedCorrectly(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="FloatDefault">
+        <field name="rate" type="float" defaultValue="3.14"/>
+    </dto>
+</dtos>
+XML;
+
+        $code = $this->generateDtoCode($xml, 'FloatDefault');
+
+        $this->assertStringContainsString('$rate = 3.14;', $code);
+    }
+
+    public function testCollectionPropertyInitializedToNull(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="CollectionInit">
+        <field name="id" type="int"/>
+        <field name="items" type="Item[]" collection="true" singular="item"/>
+    </dto>
+    <dto name="Item">
+        <field name="name" type="string"/>
+    </dto>
+</dtos>
+XML;
+
+        $code = $this->generateDtoCode($xml, 'CollectionInit');
+
+        // Collection property should be nullable and initialized to null
+        $this->assertStringContainsString('?\ArrayObject $items = null;', $code);
+    }
+
+    public function testDefaultValueInSetDefaults(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="SetDefaults">
+        <field name="active" type="bool" defaultValue="true"/>
+        <field name="name" type="string" defaultValue="default"/>
+    </dto>
+</dtos>
+XML;
+
+        $code = $this->generateDtoCode($xml, 'SetDefaults');
+
+        // setDefaults method should use proper PHP values
+        $this->assertStringContainsString('$this->active = true;', $code);
+        $this->assertStringContainsString("\$this->name = 'default';", $code);
+    }
+
+    private function generateDtoCode(string $xml, string $dtoName): string
+    {
+        $engine = new XmlEngine();
+        $config = new ArrayConfig([
+            'namespace' => 'Test',
+        ]);
+
+        $builder = new Builder($engine, $config);
+        $renderer = new TwigRenderer(null, $config);
+
+        // Create temp directory and file with proper name
+        $tmpDir = sys_get_temp_dir() . '/dto_test_' . uniqid() . '/';
+        mkdir($tmpDir);
+        $tmpFile = $tmpDir . 'dto.xml';
+        file_put_contents($tmpFile, $xml);
+
+        try {
+            $dtos = $builder->build($tmpDir);
+            $this->assertArrayHasKey($dtoName, $dtos);
+
+            $renderer->set($dtos[$dtoName]);
+
+            return $renderer->generate('dto');
+        } finally {
+            @unlink($tmpFile);
+            @rmdir($tmpDir);
+        }
+    }
+}

--- a/tests/Generator/TwigRendererTest.php
+++ b/tests/Generator/TwigRendererTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Generator\TwigRenderer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class TwigRendererTest extends TestCase
+{
+    private TwigRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new TwigRenderer();
+    }
+
+    #[DataProvider('phpExportProvider')]
+    public function testPhpExport(mixed $value, string $expected): void
+    {
+        $result = $this->renderer->phpExport($value);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function phpExportProvider(): array
+    {
+        return [
+            'boolean true' => [true, 'true'],
+            'boolean false' => [false, 'false'],
+            'null' => [null, 'null'],
+            'integer' => [42, '42'],
+            'negative integer' => [-5, '-5'],
+            'float' => [3.14, '3.14'],
+            'simple string' => ['hello', "'hello'"],
+            'string with spaces' => ['hello world', "'hello world'"],
+            'string with single quote' => ["it's", "'it\\'s'"],
+            'string with backslash' => ['path\\to\\file', "'path\\\\to\\\\file'"],
+            'empty string' => ['', "''"],
+            'zero' => [0, '0'],
+            'zero float' => [0.0, '0'],
+        ];
+    }
+
+    public function testPhpExportArray(): void
+    {
+        $result = $this->renderer->phpExport(['a', 'b']);
+        $this->assertStringContainsString("'a'", $result);
+        $this->assertStringContainsString("'b'", $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix boolean default values rendering as `1`/`0` instead of `true`/`false`
- Fix string default values rendering without quotes
- Fix collection properties causing "property must not be accessed before initialization" error

## Changes
- Add `phpExport` filter to TwigRenderer for proper PHP value rendering
- Update property.twig to use the new filter for default values
- Update property.twig to make collection properties nullable and initialize to null
- Update optimizations.twig to use phpExport filter in setDefaults

## Test plan
- [x] Added TwigRendererTest with data provider for phpExport method
- [x] Added DefaultValueRenderingTest with integration tests for generated code
- [x] All existing tests pass (451 tests, 900 assertions)
- [x] phpcs passes
- [x] phpstan passes