### PR TITLE
Add JSON Schema export feature

### DIFF
--- a/bin/dto
+++ b/bin/dto
@@ -9,15 +9,17 @@ declare(strict_types=1);
  * Usage:
  *   vendor/bin/dto generate [options]
  *   vendor/bin/dto typescript [options]
+ *   vendor/bin/dto jsonschema [options]
  *
  * Commands:
- *   generate    Generate PHP DTOs from configuration (default)
- *   typescript  Generate TypeScript interfaces from configuration
+ *   generate Generate PHP DTOs from configuration (default)
+ *   typescript Generate TypeScript interfaces from configuration
+ *   jsonschema Generate JSON Schema from configuration
  *
  * Options:
  *   --config-path=PATH Path to config directory (default: config/)
  *   --src-path=PATH Path to src directory (default: src/)
- *   --output=PATH Path for TypeScript output (default: types/)
+ *   --output=PATH Path for TypeScript/JSON Schema output (default: types/ or schemas/)
  *   --namespace=NS Namespace for generated DTOs (default: App)
  *   --format=FORMAT Config format: xml, yaml, neon (default: auto-detect)
  *   --dry-run Show what would be generated without writing files
@@ -32,6 +34,12 @@ declare(strict_types=1);
  *   --readonly Make all fields readonly
  *   --strict-nulls Use '| null' instead of '?'
  *   --file-case=CASE File naming: pascal, dashed, snake (default: pascal)
+ *
+ * JSON Schema Options:
+ *   --single-file Generate all schemas in one file with $defs (default: true)
+ *   --multi-file Generate each schema in separate file
+ *   --no-refs Inline nested DTOs instead of using $ref
+ *   --date-format=FORMAT Date format: date-time, date, string (default: date-time)
  */
 
 // Find autoloader
@@ -64,6 +72,7 @@ use PhpCollective\Dto\Generator\Builder;
 use PhpCollective\Dto\Generator\ConsoleIo;
 use PhpCollective\Dto\Generator\Generator;
 use PhpCollective\Dto\Generator\IoInterface;
+use PhpCollective\Dto\Generator\JsonSchemaGenerator;
 use PhpCollective\Dto\Generator\TwigRenderer;
 use PhpCollective\Dto\Generator\TypeScriptGenerator;
 
@@ -80,7 +89,7 @@ function parseArgs(array $argv): array
         'command' => null,
         'config-path' => 'config/',
         'src-path' => 'src/',
-        'output' => 'types/',
+        'output' => null, // Will be set based on command
         'namespace' => 'App',
         'format' => null,
         'dry-run' => false,
@@ -95,6 +104,9 @@ function parseArgs(array $argv): array
         'readonly' => false,
         'strict-nulls' => false,
         'file-case' => 'pascal',
+        // JSON Schema options
+        'use-refs' => true,
+        'date-format' => 'date-time',
     ];
 
     array_shift($argv); // Remove script name
@@ -134,6 +146,10 @@ function parseArgs(array $argv): array
             $options['format'] = substr($arg, 9);
         } elseif (str_starts_with($arg, '--file-case=')) {
             $options['file-case'] = substr($arg, 12);
+        } elseif ($arg === '--no-refs') {
+            $options['use-refs'] = false;
+        } elseif (str_starts_with($arg, '--date-format=')) {
+            $options['date-format'] = substr($arg, 14);
         } elseif (!str_starts_with($arg, '-') && $options['command'] === null) {
             $options['command'] = $arg;
         }
@@ -155,11 +171,13 @@ DTO Generator - Generate Data Transfer Objects from configuration files
 Usage:
   vendor/bin/dto generate [options]
   vendor/bin/dto typescript [options]
+  vendor/bin/dto jsonschema [options]
   vendor/bin/dto [options]
 
 Commands:
   generate    Generate PHP DTOs from configuration (default)
   typescript  Generate TypeScript interfaces from configuration
+  jsonschema  Generate JSON Schema from configuration
 
 Common Options:
   --config-path=PATH   Path to config directory (default: config/)
@@ -184,6 +202,13 @@ TypeScript Options:
   --strict-nulls       Use '| null' instead of '?'
   --file-case=CASE     File naming: pascal, dashed, snake (default: pascal)
 
+JSON Schema Options:
+  --output=PATH        Path for JSON Schema output (default: schemas/)
+  --single-file        Generate all schemas in one file with \$defs (default)
+  --multi-file         Generate each schema in separate file
+  --no-refs            Inline nested DTOs instead of using \$ref
+  --date-format=FMT    Date format: date-time, date, string (default: date-time)
+
 Examples:
   # Generate PHP DTOs with defaults (config/ -> src/Dto/)
   vendor/bin/dto generate
@@ -205,6 +230,15 @@ Examples:
 
   # TypeScript with readonly interfaces
   vendor/bin/dto typescript --readonly --strict-nulls
+
+  # Generate JSON Schema
+  vendor/bin/dto jsonschema --output=api/schemas/
+
+  # JSON Schema with separate files
+  vendor/bin/dto jsonschema --multi-file
+
+  # JSON Schema with inline DTOs (no \$ref)
+  vendor/bin/dto jsonschema --no-refs
 
 Configuration Formats:
   The generator supports XML (default), YAML, NEON, and PHP formats.
@@ -281,7 +315,7 @@ if ($args['help']) {
 // Default command is generate
 $command = $args['command'] ?? 'generate';
 
-if (!in_array($command, ['generate', 'typescript'], true)) {
+if (!in_array($command, ['generate', 'typescript', 'jsonschema'], true)) {
     fwrite(STDERR, "Unknown command: {$command}\n");
     fwrite(STDERR, "Run 'vendor/bin/dto --help' for usage.\n");
     exit(1);
@@ -310,9 +344,44 @@ if ($args['quiet']) {
 $io = new ConsoleIo($verbosity);
 
 // Handle commands
+if ($command === 'jsonschema') {
+    // JSON Schema generation
+    $outputPath = rtrim($args['output'] ?? 'schemas/', '/') . '/';
+
+    $namespace = $args['namespace'];
+    $config = new ArrayConfig([
+        'namespace' => $namespace,
+    ]);
+
+    $engine = createEngine($format);
+    $builder = new Builder($engine, $config);
+
+    $io->out("Generating JSON Schema from {$configPath} to {$outputPath}", 1, IoInterface::VERBOSE);
+    $io->out("Format: {$format}", 1, IoInterface::VERBOSE);
+    $io->out('', 1, IoInterface::VERBOSE);
+
+    try {
+        $definitions = $builder->build($configPath, []);
+    } catch (Exception $e) {
+        $io->error($e->getMessage());
+        exit(1);
+    }
+
+    $schemaGenerator = new JsonSchemaGenerator($io, [
+        'singleFile' => $args['single-file'],
+        'useRefs' => $args['use-refs'],
+        'dateFormat' => $args['date-format'],
+    ]);
+
+    $count = $schemaGenerator->generate($definitions, $outputPath);
+    $io->out("Generated {$count} JSON Schema file(s).");
+
+    exit(0);
+}
+
 if ($command === 'typescript') {
     // TypeScript generation
-    $outputPath = rtrim($args['output'], '/') . '/';
+    $outputPath = rtrim($args['output'] ?? 'types/', '/') . '/';
 
     $namespace = $args['namespace'];
     $config = new ArrayConfig([

--- a/src/Generator/JsonSchemaGenerator.php
+++ b/src/Generator/JsonSchemaGenerator.php
@@ -1,0 +1,473 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Generator;
+
+/**
+ * Generates JSON Schema from DTO definitions.
+ */
+class JsonSchemaGenerator
+{
+    /**
+     * @var array<string, string>
+     */
+    protected const TYPE_MAP = [
+        'int' => 'integer',
+        'integer' => 'integer',
+        'float' => 'number',
+        'double' => 'number',
+        'string' => 'string',
+        'bool' => 'boolean',
+        'boolean' => 'boolean',
+        'array' => 'array',
+        'mixed' => 'any',
+        'object' => 'object',
+        'null' => 'null',
+    ];
+
+    /**
+     * @var array<string>
+     */
+    protected const DATE_TYPES = [
+        '\\DateTime',
+        '\\DateTimeImmutable',
+        '\\DateTimeInterface',
+        'DateTime',
+        'DateTimeImmutable',
+        'DateTimeInterface',
+    ];
+
+    /**
+     * @var \PhpCollective\Dto\Generator\IoInterface
+     */
+    protected IoInterface $io;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $options;
+
+    /**
+     * @param \PhpCollective\Dto\Generator\IoInterface $io
+     * @param array<string, mixed> $options
+     */
+    public function __construct(IoInterface $io, array $options = [])
+    {
+        $this->io = $io;
+        $this->options = $options + [
+            'singleFile' => true,
+            'schemaVersion' => 'https://json-schema.org/draft/2020-12/schema',
+            'suffix' => 'Dto',
+            'dateFormat' => 'date-time', // date-time, date, or string
+            'useRefs' => true, // Use $ref for nested DTOs
+        ];
+    }
+
+    /**
+     * Generate JSON Schema from DTO definitions.
+     *
+     * @param array<string, array<string, mixed>> $definitions
+     * @param string $outputPath
+     *
+     * @return int Number of files generated
+     */
+    public function generate(array $definitions, string $outputPath): int
+    {
+        if (!is_dir($outputPath)) {
+            mkdir($outputPath, 0755, true);
+        }
+
+        $outputPath = rtrim($outputPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        if ($this->options['singleFile']) {
+            return $this->generateSingleFile($definitions, $outputPath);
+        }
+
+        return $this->generateMultipleFiles($definitions, $outputPath);
+    }
+
+    /**
+     * Generate all schemas in a single file with $defs.
+     *
+     * @param array<string, array<string, mixed>> $definitions
+     * @param string $outputPath
+     *
+     * @return int
+     */
+    protected function generateSingleFile(array $definitions, string $outputPath): int
+    {
+        $schema = [
+            '$schema' => $this->options['schemaVersion'],
+            '$id' => 'dto-schemas.json',
+            'title' => 'DTO Schemas',
+            'description' => 'Auto-generated JSON Schema from php-collective/dto',
+            '$defs' => [],
+        ];
+
+        foreach ($definitions as $name => $definition) {
+            $schemaName = $this->getSchemaName($name);
+            $schema['$defs'][$schemaName] = $this->generateSchemaObject($definition, $definitions, true);
+        }
+
+        $filePath = $outputPath . 'dto-schemas.json';
+        file_put_contents($filePath, json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+        $this->io->success('Generated: dto-schemas.json');
+
+        return 1;
+    }
+
+    /**
+     * Generate each schema in its own file.
+     *
+     * @param array<string, array<string, mixed>> $definitions
+     * @param string $outputPath
+     *
+     * @return int
+     */
+    protected function generateMultipleFiles(array $definitions, string $outputPath): int
+    {
+        $count = 0;
+
+        foreach ($definitions as $name => $definition) {
+            $schemaName = $this->getSchemaName($name);
+            $schema = [
+                '$schema' => $this->options['schemaVersion'],
+                '$id' => $schemaName . '.json',
+                'title' => $schemaName,
+                'description' => $definition['description'] ?? 'Auto-generated from ' . $name . ' DTO',
+            ] + $this->generateSchemaObject($definition, $definitions, false);
+
+            $fileName = $schemaName . '.json';
+            $filePath = $outputPath . $fileName;
+
+            file_put_contents($filePath, json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+            $this->io->success('Generated: ' . $fileName);
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Generate a JSON Schema object for a DTO definition.
+     *
+     * @param array<string, mixed> $definition
+     * @param array<string, array<string, mixed>> $allDefinitions
+     * @param bool $inDefs Whether we're in $defs (single file mode)
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateSchemaObject(array $definition, array $allDefinitions, bool $inDefs): array
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [],
+        ];
+
+        $required = [];
+        /** @var array<string, array<string, mixed>> $fields */
+        $fields = $definition['fields'] ?? [];
+
+        foreach ($fields as $fieldName => $field) {
+            $schema['properties'][$fieldName] = $this->mapFieldToSchema($field, $allDefinitions, $inDefs);
+
+            if (!empty($field['required'])) {
+                $required[] = $fieldName;
+            }
+        }
+
+        if ($required) {
+            $schema['required'] = $required;
+        }
+
+        // Add additionalProperties: false for strict validation
+        $schema['additionalProperties'] = false;
+
+        return $schema;
+    }
+
+    /**
+     * Map a DTO field to a JSON Schema property.
+     *
+     * @param array<string, mixed> $field
+     * @param array<string, array<string, mixed>> $allDefinitions
+     * @param bool $inDefs
+     *
+     * @return array<string, mixed>
+     */
+    protected function mapFieldToSchema(array $field, array $allDefinitions, bool $inDefs): array
+    {
+        /** @var string $type */
+        $type = $field['type'] ?? 'mixed';
+        $nullable = !empty($field['nullable']);
+        $isCollection = !empty($field['collection']) || !empty($field['isArray']);
+
+        // Handle array notation (e.g., "string[]", "int[]")
+        if (str_ends_with($type, '[]')) {
+            $innerType = substr($type, 0, -2);
+            $schema = [
+                'type' => 'array',
+                'items' => $this->mapScalarTypeToSchema($innerType, $allDefinitions, $inDefs),
+            ];
+
+            return $nullable ? $this->makeNullable($schema) : $schema;
+        }
+
+        // Handle collections
+        if ($isCollection) {
+            /** @var string|null $singularType */
+            $singularType = $field['singularType'] ?? null;
+            /** @var string|null $singularClass */
+            $singularClass = $field['singularClass'] ?? null;
+
+            $itemSchema = ['type' => 'any'];
+            if ($singularClass) {
+                $dtoName = $this->extractDtoName($singularClass);
+                if ($dtoName && isset($allDefinitions[$dtoName])) {
+                    $itemSchema = $this->getRefOrInline($dtoName, $allDefinitions, $inDefs);
+                }
+            } elseif ($singularType) {
+                $itemSchema = $this->mapScalarTypeToSchema($singularType, $allDefinitions, $inDefs);
+            }
+
+            $schema = [
+                'type' => 'array',
+                'items' => $itemSchema,
+            ];
+
+            return $nullable ? $this->makeNullable($schema) : $schema;
+        }
+
+        // Handle nested DTO
+        if (!empty($field['dto'])) {
+            /** @var string $dtoName */
+            $dtoName = $field['dto'];
+            if (isset($allDefinitions[$dtoName])) {
+                $schema = $this->getRefOrInline($dtoName, $allDefinitions, $inDefs);
+
+                return $nullable ? $this->makeNullable($schema) : $schema;
+            }
+        }
+
+        // Handle scalar types
+        $schema = $this->mapScalarTypeToSchema($type, $allDefinitions, $inDefs);
+
+        return $nullable ? $this->makeNullable($schema) : $schema;
+    }
+
+    /**
+     * Map a scalar or class type to JSON Schema.
+     *
+     * @param string $type
+     * @param array<string, array<string, mixed>> $allDefinitions
+     * @param bool $inDefs
+     *
+     * @return array<string, mixed>
+     */
+    protected function mapScalarTypeToSchema(string $type, array $allDefinitions, bool $inDefs): array
+    {
+        // Handle union types
+        if (str_contains($type, '|')) {
+            $types = explode('|', $type);
+            $schemas = [];
+            foreach ($types as $t) {
+                $t = trim($t);
+                if ($t === 'null') {
+                    continue; // Handled separately
+                }
+                $schemas[] = $this->mapSingleTypeToSchema($t, $allDefinitions, $inDefs);
+            }
+
+            if (in_array('null', $types, true)) {
+                if (count($schemas) === 1) {
+                    return $this->makeNullable($schemas[0]);
+                }
+
+                return [
+                    'oneOf' => array_merge($schemas, [['type' => 'null']]),
+                ];
+            }
+
+            if (count($schemas) === 1) {
+                return $schemas[0];
+            }
+
+            return ['oneOf' => $schemas];
+        }
+
+        return $this->mapSingleTypeToSchema($type, $allDefinitions, $inDefs);
+    }
+
+    /**
+     * Map a single type to JSON Schema.
+     *
+     * @param string $type
+     * @param array<string, array<string, mixed>> $allDefinitions
+     * @param bool $inDefs
+     *
+     * @return array<string, mixed>
+     */
+    protected function mapSingleTypeToSchema(string $type, array $allDefinitions, bool $inDefs): array
+    {
+        // Check scalar types
+        $lowerType = strtolower($type);
+        if (isset(self::TYPE_MAP[$lowerType])) {
+            $jsonType = self::TYPE_MAP[$lowerType];
+
+            if ($jsonType === 'any') {
+                return []; // Empty schema allows anything
+            }
+
+            return ['type' => $jsonType];
+        }
+
+        // Check date types
+        if (in_array($type, self::DATE_TYPES, true)) {
+            return [
+                'type' => 'string',
+                'format' => $this->options['dateFormat'],
+            ];
+        }
+
+        // Handle FQCN (starts with backslash)
+        if (str_starts_with($type, '\\')) {
+            // Check if it's a date type
+            if (in_array($type, self::DATE_TYPES, true)) {
+                return [
+                    'type' => 'string',
+                    'format' => $this->options['dateFormat'],
+                ];
+            }
+
+            // Check if it's a known DTO
+            $dtoName = $this->extractDtoName($type);
+            if ($dtoName && isset($allDefinitions[$dtoName])) {
+                return $this->getRefOrInline($dtoName, $allDefinitions, $inDefs);
+            }
+
+            // Unknown class - treat as object
+            return ['type' => 'object'];
+        }
+
+        // Check if it's a DTO reference by name
+        if (isset($allDefinitions[$type])) {
+            return $this->getRefOrInline($type, $allDefinitions, $inDefs);
+        }
+
+        // Unknown type - allow anything
+        return [];
+    }
+
+    /**
+     * Get a $ref or inline schema for a DTO.
+     *
+     * @param string $dtoName
+     * @param array<string, array<string, mixed>> $allDefinitions
+     * @param bool $inDefs
+     *
+     * @return array<string, mixed>
+     */
+    protected function getRefOrInline(string $dtoName, array $allDefinitions, bool $inDefs): array
+    {
+        if (!$this->options['useRefs']) {
+            return $this->generateSchemaObject($allDefinitions[$dtoName], $allDefinitions, $inDefs);
+        }
+
+        $schemaName = $this->getSchemaName($dtoName);
+
+        if ($inDefs) {
+            return ['$ref' => '#/$defs/' . $schemaName];
+        }
+
+        return ['$ref' => $schemaName . '.json'];
+    }
+
+    /**
+     * Make a schema nullable.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    protected function makeNullable(array $schema): array
+    {
+        // If schema has a type, add null to it
+        if (isset($schema['type']) && is_string($schema['type'])) {
+            return [
+                'oneOf' => [
+                    $schema,
+                    ['type' => 'null'],
+                ],
+            ];
+        }
+
+        // If schema is a $ref, wrap in oneOf
+        if (isset($schema['$ref'])) {
+            return [
+                'oneOf' => [
+                    $schema,
+                    ['type' => 'null'],
+                ],
+            ];
+        }
+
+        // Already a oneOf or complex schema
+        if (isset($schema['oneOf']) && is_array($schema['oneOf'])) {
+            $schema['oneOf'][] = ['type' => 'null'];
+
+            return $schema;
+        }
+
+        // Fallback: wrap in oneOf
+        return [
+            'oneOf' => [
+                $schema,
+                ['type' => 'null'],
+            ],
+        ];
+    }
+
+    /**
+     * Get the schema name for a DTO.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function getSchemaName(string $name): string
+    {
+        /** @var string $suffix */
+        $suffix = $this->options['suffix'];
+
+        // Add suffix if not present
+        if (!str_ends_with($name, $suffix)) {
+            return $name . $suffix;
+        }
+
+        return $name;
+    }
+
+    /**
+     * Extract DTO name from a fully qualified class name.
+     *
+     * @param string $fqcn
+     *
+     * @return string|null
+     */
+    protected function extractDtoName(string $fqcn): ?string
+    {
+        $parts = explode('\\', trim($fqcn, '\\'));
+        $className = end($parts);
+
+        /** @var string $suffix */
+        $suffix = $this->options['suffix'];
+
+        // Remove suffix if present
+        if (str_ends_with($className, $suffix)) {
+            return substr($className, 0, -strlen($suffix));
+        }
+
+        return $className;
+    }
+}

--- a/tests/Generator/JsonSchemaGeneratorTest.php
+++ b/tests/Generator/JsonSchemaGeneratorTest.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Test\Generator;
+
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\IoInterface;
+use PhpCollective\Dto\Generator\JsonSchemaGenerator;
+use PHPUnit\Framework\TestCase;
+
+class JsonSchemaGeneratorTest extends TestCase
+{
+    protected string $tempDir;
+
+    /**
+     * @var resource
+     */
+    protected $stdout;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/json_schema_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        $this->stdout = fopen('php://memory', 'r+');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+        fclose($this->stdout);
+    }
+
+    protected function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    protected function createIo(): ConsoleIo
+    {
+        return new ConsoleIo(IoInterface::QUIET, $this->stdout, $this->stdout);
+    }
+
+    public function testGenerateSingleFile(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                    'name' => ['name' => 'name', 'type' => 'string', 'required' => true],
+                    'email' => ['name' => 'email', 'type' => 'string'],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $count = $generator->generate($definitions, $this->tempDir);
+
+        $this->assertSame(1, $count);
+        $this->assertFileExists($this->tempDir . '/dto-schemas.json');
+
+        $content = file_get_contents($this->tempDir . '/dto-schemas.json');
+        $schema = json_decode($content, true);
+
+        $this->assertSame('https://json-schema.org/draft/2020-12/schema', $schema['$schema']);
+        $this->assertArrayHasKey('$defs', $schema);
+        $this->assertArrayHasKey('UserDto', $schema['$defs']);
+        $this->assertSame('object', $schema['$defs']['UserDto']['type']);
+        $this->assertArrayHasKey('id', $schema['$defs']['UserDto']['properties']);
+        $this->assertSame('integer', $schema['$defs']['UserDto']['properties']['id']['type']);
+        $this->assertSame('string', $schema['$defs']['UserDto']['properties']['name']['type']);
+        $this->assertContains('id', $schema['$defs']['UserDto']['required']);
+        $this->assertContains('name', $schema['$defs']['UserDto']['required']);
+        $this->assertNotContains('email', $schema['$defs']['UserDto']['required']);
+    }
+
+    public function testGenerateMultipleFiles(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+            'Address' => [
+                'name' => 'Address',
+                'fields' => [
+                    'street' => ['name' => 'street', 'type' => 'string', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo(), ['singleFile' => false]);
+        $count = $generator->generate($definitions, $this->tempDir);
+
+        $this->assertSame(2, $count);
+        $this->assertFileExists($this->tempDir . '/UserDto.json');
+        $this->assertFileExists($this->tempDir . '/AddressDto.json');
+
+        $userSchema = json_decode(file_get_contents($this->tempDir . '/UserDto.json'), true);
+        $this->assertSame('UserDto.json', $userSchema['$id']);
+        $this->assertSame('UserDto', $userSchema['title']);
+    }
+
+    public function testTypeMapping(): void
+    {
+        $definitions = [
+            'Test' => [
+                'name' => 'Test',
+                'fields' => [
+                    'intField' => ['name' => 'intField', 'type' => 'int', 'required' => true],
+                    'floatField' => ['name' => 'floatField', 'type' => 'float', 'required' => true],
+                    'stringField' => ['name' => 'stringField', 'type' => 'string', 'required' => true],
+                    'boolField' => ['name' => 'boolField', 'type' => 'bool', 'required' => true],
+                    'arrayField' => ['name' => 'arrayField', 'type' => 'array', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $properties = $schema['$defs']['TestDto']['properties'];
+
+        $this->assertSame('integer', $properties['intField']['type']);
+        $this->assertSame('number', $properties['floatField']['type']);
+        $this->assertSame('string', $properties['stringField']['type']);
+        $this->assertSame('boolean', $properties['boolField']['type']);
+        $this->assertSame('array', $properties['arrayField']['type']);
+    }
+
+    public function testArrayTypes(): void
+    {
+        $definitions = [
+            'Test' => [
+                'name' => 'Test',
+                'fields' => [
+                    'stringArray' => ['name' => 'stringArray', 'type' => 'string[]', 'required' => true],
+                    'intArray' => ['name' => 'intArray', 'type' => 'int[]', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $properties = $schema['$defs']['TestDto']['properties'];
+
+        $this->assertSame('array', $properties['stringArray']['type']);
+        $this->assertSame('string', $properties['stringArray']['items']['type']);
+
+        $this->assertSame('array', $properties['intArray']['type']);
+        $this->assertSame('integer', $properties['intArray']['items']['type']);
+    }
+
+    public function testNullableTypes(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true, 'nullable' => false],
+                    'email' => ['name' => 'email', 'type' => 'string', 'nullable' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $properties = $schema['$defs']['UserDto']['properties'];
+
+        // Non-nullable should just have the type
+        $this->assertSame('integer', $properties['id']['type']);
+
+        // Nullable should use oneOf
+        $this->assertArrayHasKey('oneOf', $properties['email']);
+        $types = array_column($properties['email']['oneOf'], 'type');
+        $this->assertContains('string', $types);
+        $this->assertContains('null', $types);
+    }
+
+    public function testNestedDtoWithRefs(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+            'Order' => [
+                'name' => 'Order',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                    'customer' => [
+                        'name' => 'customer',
+                        'type' => '\\App\\Dto\\UserDto',
+                        'required' => true,
+                        'dto' => 'User',
+                    ],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo(), ['useRefs' => true]);
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+
+        $this->assertSame('#/$defs/UserDto', $schema['$defs']['OrderDto']['properties']['customer']['$ref']);
+    }
+
+    public function testNestedDtoWithoutRefs(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+            'Order' => [
+                'name' => 'Order',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                    'customer' => [
+                        'name' => 'customer',
+                        'type' => '\\App\\Dto\\UserDto',
+                        'required' => true,
+                        'dto' => 'User',
+                    ],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo(), ['useRefs' => false]);
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $customerSchema = $schema['$defs']['OrderDto']['properties']['customer'];
+
+        // Should be inlined, not a $ref
+        $this->assertArrayNotHasKey('$ref', $customerSchema);
+        $this->assertSame('object', $customerSchema['type']);
+        $this->assertArrayHasKey('properties', $customerSchema);
+        $this->assertArrayHasKey('id', $customerSchema['properties']);
+    }
+
+    public function testCollectionTypes(): void
+    {
+        $definitions = [
+            'Item' => [
+                'name' => 'Item',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+            'Order' => [
+                'name' => 'Order',
+                'fields' => [
+                    'items' => [
+                        'name' => 'items',
+                        'type' => 'Item[]',
+                        'collection' => true,
+                        'singularType' => 'Item',
+                        'singularClass' => '\\App\\Dto\\ItemDto',
+                    ],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $itemsSchema = $schema['$defs']['OrderDto']['properties']['items'];
+
+        $this->assertSame('array', $itemsSchema['type']);
+        $this->assertSame('#/$defs/ItemDto', $itemsSchema['items']['$ref']);
+    }
+
+    public function testDateTimeMapping(): void
+    {
+        $definitions = [
+            'Event' => [
+                'name' => 'Event',
+                'fields' => [
+                    'createdAt' => ['name' => 'createdAt', 'type' => '\\DateTime', 'required' => true],
+                    'updatedAt' => ['name' => 'updatedAt', 'type' => '\\DateTimeImmutable'],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $properties = $schema['$defs']['EventDto']['properties'];
+
+        $this->assertSame('string', $properties['createdAt']['type']);
+        $this->assertSame('date-time', $properties['createdAt']['format']);
+    }
+
+    public function testDateFormatOption(): void
+    {
+        $definitions = [
+            'Event' => [
+                'name' => 'Event',
+                'fields' => [
+                    'createdAt' => ['name' => 'createdAt', 'type' => '\\DateTime', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo(), ['dateFormat' => 'date']);
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+
+        $this->assertSame('date', $schema['$defs']['EventDto']['properties']['createdAt']['format']);
+    }
+
+    public function testCreatesOutputDirectory(): void
+    {
+        $nestedDir = $this->tempDir . '/nested/output/path';
+
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $nestedDir);
+
+        $this->assertDirectoryExists($nestedDir);
+        $this->assertFileExists($nestedDir . '/dto-schemas.json');
+    }
+
+    public function testAdditionalPropertiesFalse(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+
+        $this->assertFalse($schema['$defs']['UserDto']['additionalProperties']);
+    }
+
+    public function testUnionTypes(): void
+    {
+        $definitions = [
+            'Test' => [
+                'name' => 'Test',
+                'fields' => [
+                    'value' => ['name' => 'value', 'type' => 'int|string', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+        $valueSchema = $schema['$defs']['TestDto']['properties']['value'];
+
+        $this->assertArrayHasKey('oneOf', $valueSchema);
+        $types = array_column($valueSchema['oneOf'], 'type');
+        $this->assertContains('integer', $types);
+        $this->assertContains('string', $types);
+    }
+
+    public function testMixedTypeAllowsAnything(): void
+    {
+        $definitions = [
+            'Test' => [
+                'name' => 'Test',
+                'fields' => [
+                    'data' => ['name' => 'data', 'type' => 'mixed', 'required' => true],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo());
+        $generator->generate($definitions, $this->tempDir);
+
+        $schema = json_decode(file_get_contents($this->tempDir . '/dto-schemas.json'), true);
+
+        // Empty schema allows anything in JSON Schema
+        $this->assertEmpty($schema['$defs']['TestDto']['properties']['data']);
+    }
+
+    public function testMultiFileWithExternalRefs(): void
+    {
+        $definitions = [
+            'User' => [
+                'name' => 'User',
+                'fields' => [
+                    'id' => ['name' => 'id', 'type' => 'int', 'required' => true],
+                ],
+            ],
+            'Order' => [
+                'name' => 'Order',
+                'fields' => [
+                    'customer' => [
+                        'name' => 'customer',
+                        'type' => '\\App\\Dto\\UserDto',
+                        'required' => true,
+                        'dto' => 'User',
+                    ],
+                ],
+            ],
+        ];
+
+        $generator = new JsonSchemaGenerator($this->createIo(), ['singleFile' => false]);
+        $generator->generate($definitions, $this->tempDir);
+
+        $orderSchema = json_decode(file_get_contents($this->tempDir . '/OrderDto.json'), true);
+
+        // Multi-file mode should use external file refs
+        $this->assertSame('UserDto.json', $orderSchema['properties']['customer']['$ref']);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `JsonSchemaGenerator` class for generating JSON Schema from DTO definitions
- Add `jsonschema` command to CLI (`vendor/bin/dto jsonschema`)
- Support single-file output with `$defs` or multi-file with external `$ref`
- Map PHP types to JSON Schema types appropriately
- Support nested DTOs, collections, nullable types, and DateTime fields

## Features

### CLI Options
- `--output=PATH` - Path for JSON Schema output (default: schemas/)
- `--single-file` - Generate all schemas in one file with `$defs` (default)
- `--multi-file` - Generate each schema in separate file
- `--no-refs` - Inline nested DTOs instead of using `$ref`
- `--date-format=FMT` - Date format: date-time, date, string (default: date-time)

### Type Mapping
| PHP Type | JSON Schema Type |
|----------|------------------|
| int/integer | integer |
| float/double | number |
| string | string |
| bool/boolean | boolean |
| array | array |
| mixed | (empty - allows anything) |
| DateTime/DateTimeImmutable | string with format |

### Example Output

```json
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "$id": "dto-schemas.json",
    "title": "DTO Schemas",
    "$defs": {
        "UserDto": {
            "type": "object",
            "properties": {
                "id": {"type": "integer"},
                "name": {"type": "string"},
                "email": {"oneOf": [{"type": "string"}, {"type": "null"}]}
            },
            "required": ["id", "name"],
            "additionalProperties": false
        }
    }
}
```

## Test plan

- [x] Unit tests for JsonSchemaGenerator class (15 tests, 48 assertions)
- [x] PHPStan analysis passes
- [x] PHPCS passes
- [x] Full test suite passes

Closes #31