### PR TITLE
Add $ref resolution support to JSON Schema importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Unlike runtime reflection libraries, this library generates optimized DTO classe
 - **Perfect IDE autocomplete** with real methods
 - **Excellent static analysis** support (PHPStan/Psalm work out of the box)
 - **Reviewable generated code** in pull requests
+- **JSON Schema generation** for API documentation
+- **Schema importer** to bootstrap DTOs from JSON data or OpenAPI specs
 
 See [Motivation](docs/Motivation.md) for why code generation beats runtime reflection.
 


### PR DESCRIPTION
## Summary

- Add support for resolving `$ref` pointers in JSON Schema definitions
- Supports `#/$defs/Name` (JSON Schema draft-07+), `#/definitions/Name` (older JSON Schema), and `#/components/schemas/Name` (OpenAPI 3.x)
- Automatically creates DTOs for referenced schemas with deduplication
- Supports `$ref` in array items for collections
- Gracefully skips unresolvable and external file refs
- Highlights JSON Schema generation and Schema Importer as key differentiators in README

## Example

Input JSON Schema:
```json
{
  "$defs": {
    "Address": {
      "type": "object",
      "properties": {
        "street": { "type": "string" },
        "city": { "type": "string" }
      }
    }
  },
  "type": "object",
  "title": "Customer",
  "properties": {
    "name": { "type": "string" },
    "billingAddress": { "$ref": "#/$defs/Address" },
    "shippingAddress": { "$ref": "#/$defs/Address" }
  }
}
```

Output DTOs:
```php
Schema::create()
    ->dto(Dto::create('Address')->fields(
        Field::string('street'),
        Field::string('city'),
    ))
    ->dto(Dto::create('Customer')->fields(
        Field::string('name'),
        Field::dto('billingAddress', 'Address'),
        Field::dto('shippingAddress', 'Address'),
    ))
```

## Test plan

- [x] Added tests for `$defs` resolution
- [x] Added tests for `definitions` resolution (older JSON Schema)
- [x] Added tests for `components/schemas` resolution (OpenAPI)
- [x] Added tests for `$ref` in array items
- [x] Added tests for deduplication when same `$ref` is used twice
- [x] Added tests for skipping unresolvable refs
- [x] Added tests for skipping external file refs
- [x] All existing tests pass