### PR TITLE
Add format specifier support to Schema Importer

### DIFF
--- a/docs/Importer.md
+++ b/docs/Importer.md
@@ -265,6 +265,16 @@ $schema = $importer->importArray($data, ['format' => 'php']);
 | `object` | Nested DTO |
 | `["string", "null"]` | `string` (optional) |
 
+### Format Specifiers
+
+| JSON Schema Format | DTO Type |
+|--------------------|----------|
+| `date-time` | `\DateTimeInterface` |
+| `date` | `\DateTimeInterface` |
+| `email`, `uri`, `uuid`, etc. | `string` (unchanged) |
+
+Note: Only `date-time` and `date` formats are mapped to class types. Other formats like `email`, `uri`, `uuid` remain as `string` since they are validation hints rather than type indicators.
+
 ## Limitations
 
 The importer is a scaffolding tool. Generated configs typically need manual refinement:

--- a/tests/Importer/Parser/SchemaParserTest.php
+++ b/tests/Importer/Parser/SchemaParserTest.php
@@ -630,4 +630,78 @@ class SchemaParserTest extends TestCase
 
         $this->assertArrayHasKey('Api/User', $result);
     }
+
+    /**
+     * @return void
+     */
+    public function testFormatDateTime(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'createdAt' => ['type' => 'string', 'format' => 'date-time'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('\\DateTimeInterface', $result['Object']['createdAt']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFormatDate(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'birthDate' => ['type' => 'string', 'format' => 'date'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('\\DateTimeInterface', $result['Object']['birthDate']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFormatEmailRemainsString(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'email' => ['type' => 'string', 'format' => 'email'],
+                'website' => ['type' => 'string', 'format' => 'uri'],
+                'id' => ['type' => 'string', 'format' => 'uuid'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        // These formats don't change the type - they're just validation hints
+        $this->assertSame('string', $result['Object']['email']['type']);
+        $this->assertSame('string', $result['Object']['website']['type']);
+        $this->assertSame('string', $result['Object']['id']['type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFormatOnlyAppliestoStringType(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                // Format on non-string type should be ignored
+                'timestamp' => ['type' => 'integer', 'format' => 'int64'],
+            ],
+        ];
+
+        $result = $this->parser->parse($schema)->result();
+
+        $this->assertSame('int', $result['Object']['timestamp']['type']);
+    }
 }


### PR DESCRIPTION
## Summary

Map JSON Schema `format` values to appropriate DTO types during import:

| Format | DTO Type |
|--------|----------|
| `date-time` | `\DateTimeInterface` |
| `date` | `\DateTimeInterface` |
| `email`, `uri`, `uuid`, etc. | `string` (unchanged) |

This allows automatic detection of date/time fields from JSON Schema and OpenAPI specifications.

## Example

Input:
```json
{
  "type": "object",
  "properties": {
    "createdAt": {"type": "string", "format": "date-time"},
    "email": {"type": "string", "format": "email"}
  }
}
```

Output:
```php
Dto::create('Object')->fields(
    Field::class('createdAt', '\\DateTimeInterface'),
    Field::string('email'),
)
```

## Test plan

- [x] Test `date-time` format → `\DateTimeInterface`
- [x] Test `date` format → `\DateTimeInterface`
- [x] Test other formats (`email`, `uri`, `uuid`) remain as `string`
- [x] Test format on non-string types is ignored
- [x] Updated documentation with format specifier table