### PR TITLE
Mark Serializable interface methods as deprecated

### DIFF
--- a/src/Dto/AbstractDto.php
+++ b/src/Dto/AbstractDto.php
@@ -26,6 +26,8 @@ abstract class AbstractDto extends Dto
      *
      * @link https://php.net/manual/en/serializable.unserialize.php
      *
+     * @deprecated Use __unserialize() instead. The Serializable interface is deprecated in PHP 8.1+.
+     *
      * @param string $serialized
      * @param bool $ignoreMissing
      *

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -125,6 +125,8 @@ abstract class Dto implements Serializable
      *
      * @link https://php.net/manual/en/serializable.unserialize.php
      *
+     * @deprecated Use __unserialize() instead. The Serializable interface is deprecated in PHP 8.1+.
+     *
      * @param string $data
      * @param bool $ignoreMissing
      *
@@ -793,6 +795,8 @@ abstract class Dto implements Serializable
      * String representation of object
      *
      * @link https://php.net/manual/en/serializable.serialize.php
+     *
+     * @deprecated Use __serialize() instead. The Serializable interface is deprecated in PHP 8.1+.
      *
      * @return string the string representation of the object or null
      */


### PR DESCRIPTION
## Summary

- Added `@deprecated` annotations to `serialize()` and `unserialize()` methods
- The `Serializable` interface is deprecated in PHP 8.1+
- Users should use `__serialize()` and `__unserialize()` instead (already implemented)

## Changes

- `src/Dto/Dto.php`: Mark `serialize()` and `unserialize()` as deprecated
- `src/Dto/AbstractDto.php`: Mark `unserialize()` as deprecated

## Test plan

- [x] PHPStan passes
- [x] PHPCS passes  
- [x] All 519 tests pass