### PR TITLE
Allow underscore-prefixed field names

### DIFF
--- a/src/Generator/TypeValidator.php
+++ b/src/Generator/TypeValidator.php
@@ -63,7 +63,8 @@ class TypeValidator
      */
     public function isValidName(string $name): bool
     {
-        return (bool)preg_match('#^[a-zA-Z][a-zA-Z0-9]+$#', $name);
+        // Allow optional underscore prefix for framework special fields (e.g., _joinData, _matchingData)
+        return (bool)preg_match('#^_?[a-zA-Z][a-zA-Z0-9]*$#', $name);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Allows field names starting with underscore (e.g., `_joinData`, `_matchingData`)

This enables support for framework special fields like CakePHP's `_joinData` (BelongsToMany pivot data) and `_matchingData` (matching query results) used with the `projectAs()` ORM feature.

The regex change:
- Before: `#^[a-zA-Z][a-zA-Z0-9]+$#`
- After: `#^_?[a-zA-Z][a-zA-Z0-9]*$#`

Also changed `+` to `*` to allow shorter field names like single letters (e.g., `x`).