### PR TITLE
Fix method names for underscore-prefixed fields

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -392,6 +392,27 @@ class Builder
                 }
             }
         }
+
+        // Check for method name collisions between underscore-prefixed and non-prefixed fields
+        // e.g., '_foo' and 'foo' would both generate 'getFoo()', 'setFoo()', etc.
+        $methodNames = [];
+        foreach ($fields as $array) {
+            $fieldName = $array['name'];
+            $methodName = Inflector::camelize($fieldName);
+
+            if (isset($methodNames[$methodName])) {
+                throw new InvalidArgumentException(sprintf(
+                    "Field name collision in '%s' DTO: fields '%s' and '%s' would generate identical method names.\n"
+                    . "Hint: Both fields would generate methods like 'get%s()', 'set%s()', etc. Use only one of these field names.",
+                    $dtoName,
+                    $methodNames[$methodName],
+                    $fieldName,
+                    $methodName,
+                    $methodName,
+                ));
+            }
+            $methodNames[$methodName] = $fieldName;
+        }
     }
 
     /**

--- a/templates/element/method_add.twig
+++ b/templates/element/method_add.twig
@@ -10,7 +10,7 @@
 	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return $this
 	 */
-	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
+	public function add{{ singular|camelize }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
 	{
 		if ($this->{{ name }} === null) {
 			$this->{{ name }} = {% if collectionType == 'array' %}[]{% else %}new {{ typeHint }}([]){% endif %};

--- a/templates/element/method_get.twig
+++ b/templates/element/method_get.twig
@@ -6,7 +6,7 @@
 	 * @return {{ docBlockType ?? type }}{% if nullable %}|null{% endif %}
 
 	 */
-	public function get{{ name[:1]|upper ~ name[1:] }}(){% if returnTypeHint %}: {{ nullableReturnTypeHint ?? returnTypeHint }}{% endif %}
+	public function get{{ name|camelize }}(){% if returnTypeHint %}: {{ nullableReturnTypeHint ?? returnTypeHint }}{% endif %}
 
 	{
 {% if collection %}
@@ -33,7 +33,7 @@
 	 * @throws \RuntimeException If value with this key is not set.
 {% endif %}
 	 */
-	public function get{{ singular[:1]|upper ~ singular[1:] }}($key){% if singularReturnTypeHint %}: {{ singularNullableReturnTypeHint ?? singularReturnTypeHint }}{% endif %}
+	public function get{{ singular|camelize }}($key){% if singularReturnTypeHint %}: {{ singularNullableReturnTypeHint ?? singularReturnTypeHint }}{% endif %}
 
 	{
 {% if singularNullable %}

--- a/templates/element/method_get_or_fail.twig
+++ b/templates/element/method_get_or_fail.twig
@@ -7,7 +7,7 @@
 	 *
 	 * @return {{ docBlockType ?? type }}
 	 */
-	public function get{{ name[:1]|upper ~ name[1:] }}OrFail(){% if returnTypeHint %}: {{ returnTypeHint }}{% endif %}
+	public function get{{ name|camelize }}OrFail(){% if returnTypeHint %}: {{ returnTypeHint }}{% endif %}
 
 	{
 		if ($this->{{ name }} === null) {

--- a/templates/element/method_has.twig
+++ b/templates/element/method_has.twig
@@ -5,7 +5,7 @@
 {% endif %}
 	 * @return bool
 	 */
-	public function has{{ name[:1]|upper ~ name[1:] }}(): bool
+	public function has{{ name|camelize }}(): bool
 	{
 {% if collectionType %}
 		if ($this->{{ name }} === null) {
@@ -32,7 +32,7 @@
 	 * @param {{ keyType }} $key
 	 * @return bool
 	 */
-	public function has{{ singular[:1]|upper ~ singular[1:] }}($key): bool
+	public function has{{ singular|camelize }}($key): bool
 	{
 		return isset($this->{{ name }}[$key]);
 	}

--- a/templates/element/method_set.twig
+++ b/templates/element/method_set.twig
@@ -7,7 +7,7 @@
 	 *
 	 * @return $this
 	 */
-	public function set{{ name[:1]|upper ~ name[1:] }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if nullable %} = null{% endif %})
+	public function set{{ name|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if nullable %} = null{% endif %})
 	{
 		$this->{{ name }} = ${{ name }};
 		$this->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;

--- a/templates/element/method_set_or_fail.twig
+++ b/templates/element/method_set_or_fail.twig
@@ -11,7 +11,7 @@
 	 *
 	 * @return $this
 	 */
-	public function set{{ name[:1]|upper ~ name[1:] }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
+	public function set{{ name|camelize }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
 	{
 {% if not typeHint %}
 		if (${{ name }} === null) {

--- a/templates/element/method_with.twig
+++ b/templates/element/method_with.twig
@@ -7,7 +7,7 @@
 	 *
 	 * @return static
 	 */
-	public function with{{ name[:1]|upper ~ name[1:] }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %})
+	public function with{{ name|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %})
 	{
 		$new = clone $this;
 		$new->{{ name }} = ${{ name }};

--- a/templates/element/method_with_added.twig
+++ b/templates/element/method_with_added.twig
@@ -10,7 +10,7 @@
 	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
+	public function withAdded{{ singular|camelize }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
 	{
 		$new = clone $this;
 

--- a/templates/element/method_with_or_fail.twig
+++ b/templates/element/method_with_or_fail.twig
@@ -11,7 +11,7 @@
 	 *
 	 * @return static
 	 */
-	public function with{{ name[:1]|upper ~ name[1:] }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
+	public function with{{ name|camelize }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
 	{
 {% if not typeHint %}
 		if (${{ name }} === null) {

--- a/templates/element/optimizations.twig
+++ b/templates/element/optimizations.twig
@@ -10,7 +10,7 @@
 	 */
 	protected static array $_setters = [
 {% for field in fields %}
-		'{{ field.name }}' => '{% if immutable %}with{% else %}set{% endif %}{{ field.name | capitalize }}',
+		'{{ field.name }}' => '{% if immutable %}with{% else %}set{% endif %}{{ field.name | camelize }}',
 {% endfor %}
 	];
 

--- a/tests/Generator/TwigRendererTest.php
+++ b/tests/Generator/TwigRendererTest.php
@@ -49,4 +49,61 @@ class TwigRendererTest extends TestCase
         $this->assertStringContainsString("'a'", $result);
         $this->assertStringContainsString("'b'", $result);
     }
+
+    public function testUnderscorePrefixedFieldGeneratesCorrectMethodNames(): void
+    {
+        // Test that underscore-prefixed field names generate camelCase method names
+        $this->renderer->set([
+            'name' => '_joinData',
+            'type' => 'string',
+            'nullable' => true,
+            'typeHint' => 'string',
+            'nullableTypeHint' => '?string',
+            'returnTypeHint' => 'string',
+            'nullableReturnTypeHint' => '?string',
+            'deprecated' => null,
+            'collection' => false,
+            'collectionType' => null,
+        ]);
+
+        // Test getter method name
+        $getterOutput = $this->renderer->generate('element/method_get');
+        $this->assertStringContainsString('public function getJoinData()', $getterOutput);
+        $this->assertStringNotContainsString('get_joinData', $getterOutput);
+
+        // Test has method name
+        $hasOutput = $this->renderer->generate('element/method_has');
+        $this->assertStringContainsString('public function hasJoinData()', $hasOutput);
+        $this->assertStringNotContainsString('has_joinData', $hasOutput);
+
+        // Test setter method name (for mutable DTOs)
+        $setterOutput = $this->renderer->generate('element/method_set');
+        $this->assertStringContainsString('public function setJoinData(', $setterOutput);
+        $this->assertStringNotContainsString('set_joinData', $setterOutput);
+
+        // Test with method name (for immutable DTOs)
+        $withOutput = $this->renderer->generate('element/method_with');
+        $this->assertStringContainsString('public function withJoinData(', $withOutput);
+        $this->assertStringNotContainsString('with_joinData', $withOutput);
+    }
+
+    public function testRegularFieldGeneratesCorrectMethodNames(): void
+    {
+        // Verify regular fields still work correctly
+        $this->renderer->set([
+            'name' => 'userName',
+            'type' => 'string',
+            'nullable' => true,
+            'typeHint' => 'string',
+            'nullableTypeHint' => '?string',
+            'returnTypeHint' => 'string',
+            'nullableReturnTypeHint' => '?string',
+            'deprecated' => null,
+            'collection' => false,
+            'collectionType' => null,
+        ]);
+
+        $getterOutput = $this->renderer->generate('element/method_get');
+        $this->assertStringContainsString('public function getUserName()', $getterOutput);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes regression from #51 where underscore-prefixed field names generated non-camelCase method names
- `_joinData` now generates `getJoinData()`, `withJoinData()` etc. instead of `get_joinData()`
- Adds collision validation to prevent both `_foo` and `foo` fields in the same DTO

This enables CakePHP's `_joinData` (BelongsToMany pivot data) and `_matchingData` (matching query results) to work properly with DTOs while maintaining PSR-1 compliant method names.

The underscore is preserved in:
- Property names (`$_joinData`)
- Array keys in `toArray()` output
- `createFromArray()` input

Users can still use `mapFrom`/`mapTo` for additional flexibility if needed.