### PR TITLE
Fix constant names for underscore-prefixed fields

### DIFF
--- a/templates/element/constants.twig
+++ b/templates/element/constants.twig
@@ -3,13 +3,13 @@
 	/**
 	 * @deprecated {{ field.deprecated }}
 	 */
-	public const FIELD_{{ field.name | underscore | upper }} = '{{ field.name }}';
+	public const FIELD_{{ field.name | camelize | underscore | upper }} = '{{ field.name }}';
 {% elseif typedConstants %}
-	public const string FIELD_{{ field.name | underscore | upper }} = '{{ field.name }}';
+	public const string FIELD_{{ field.name | camelize | underscore | upper }} = '{{ field.name }}';
 {% else %}
 	/**
 	 * @var string
 	 */
-	public const FIELD_{{ field.name | underscore | upper }} = '{{ field.name }}';
+	public const FIELD_{{ field.name | camelize | underscore | upper }} = '{{ field.name }}';
 {% endif %}
 {% endfor -%}

--- a/templates/element/method_add.twig
+++ b/templates/element/method_add.twig
@@ -21,7 +21,7 @@
 {% else %}
 		$this->{{ name }}[] = ${{ singular }};
 {% endif %}
-		$this->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;
+		$this->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
 
 		return $this;
 	}

--- a/templates/element/method_set.twig
+++ b/templates/element/method_set.twig
@@ -10,7 +10,7 @@
 	public function set{{ name|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if nullable %} = null{% endif %})
 	{
 		$this->{{ name }} = ${{ name }};
-		$this->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;
+		$this->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
 
 		return $this;
 	}

--- a/templates/element/method_set_or_fail.twig
+++ b/templates/element/method_set_or_fail.twig
@@ -19,7 +19,7 @@
 		}
 {% endif %}
 		$this->{{ name }} = ${{ name }};
-		$this->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;
+		$this->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
 
 		return $this;
 	}

--- a/templates/element/method_with.twig
+++ b/templates/element/method_with.twig
@@ -11,7 +11,7 @@
 	{
 		$new = clone $this;
 		$new->{{ name }} = ${{ name }};
-		$new->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;
+		$new->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
 
 		return $new;
 	}

--- a/templates/element/method_with_added.twig
+++ b/templates/element/method_with_added.twig
@@ -23,7 +23,7 @@
 {% else %}
 		$new->{{ name }}[] = ${{ singular }};
 {% endif %}
-		$new->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;
+		$new->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
 
 		return $new;
 	}

--- a/templates/element/method_with_or_fail.twig
+++ b/templates/element/method_with_or_fail.twig
@@ -20,7 +20,7 @@
 {% endif %}
 		$new = clone $this;
 		$new->{{ name }} = ${{ name }};
-		$new->_touchedFields[static::FIELD_{{ name | underscore | upper }}] = true;
+		$new->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
 
 		return $new;
 	}


### PR DESCRIPTION
## Summary

- Fixes constant names for underscore-prefixed fields like `_joinData` and `_matchingData`
- Before: `FIELD__MATCHING_DATA` (double underscore)
- After: `FIELD_MATCHING_DATA` (single underscore)

## Changes

Updated templates to use `|camelize|underscore|upper` instead of `|underscore|upper`:
- `templates/element/constants.twig`
- `templates/element/method_set.twig`
- `templates/element/method_set_or_fail.twig`
- `templates/element/method_with.twig`
- `templates/element/method_with_added.twig`
- `templates/element/method_with_or_fail.twig`
- `templates/element/method_add.twig`

Added tests in `tests/Generator/TwigRendererTest.php`

## Test plan

- [x] All existing tests pass (527 tests)
- [x] New tests verify correct constant naming
- [x] phpcs passes
- [x] phpstan passes