### PR TITLE
Fix method/constant names for underscore-prefixed fields

### DIFF
--- a/src/Generator/TwigRenderer.php
+++ b/src/Generator/TwigRenderer.php
@@ -62,6 +62,26 @@ class TwigRenderer implements RendererInterface
         $this->twig->addFilter(new TwigFilter('underscore', [Inflector::class, 'underscore']));
         $this->twig->addFilter(new TwigFilter('camelize', [Inflector::class, 'camelize']));
         $this->twig->addFilter(new TwigFilter('variable', [Inflector::class, 'variable']));
+        $this->twig->addFilter(new TwigFilter('stripLeadingUnderscore', [$this, 'stripLeadingUnderscore']));
+    }
+
+    /**
+     * Strip leading underscore from a string.
+     *
+     * Used for underscore-prefixed field names (e.g., _joinData, _matchingData)
+     * to generate proper camelCase method names and constant names.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public function stripLeadingUnderscore(string $value): string
+    {
+        if (str_starts_with($value, '_')) {
+            return substr($value, 1);
+        }
+
+        return $value;
     }
 
     /**

--- a/templates/element/constants.twig
+++ b/templates/element/constants.twig
@@ -3,13 +3,13 @@
 	/**
 	 * @deprecated {{ field.deprecated }}
 	 */
-	public const FIELD_{{ field.name | camelize | underscore | upper }} = '{{ field.name }}';
+	public const FIELD_{{ field.name | stripLeadingUnderscore | camelize | underscore | upper }} = '{{ field.name }}';
 {% elseif typedConstants %}
-	public const string FIELD_{{ field.name | camelize | underscore | upper }} = '{{ field.name }}';
+	public const string FIELD_{{ field.name | stripLeadingUnderscore | camelize | underscore | upper }} = '{{ field.name }}';
 {% else %}
 	/**
 	 * @var string
 	 */
-	public const FIELD_{{ field.name | camelize | underscore | upper }} = '{{ field.name }}';
+	public const FIELD_{{ field.name | stripLeadingUnderscore | camelize | underscore | upper }} = '{{ field.name }}';
 {% endif %}
 {% endfor -%}

--- a/templates/element/method_add.twig
+++ b/templates/element/method_add.twig
@@ -10,7 +10,7 @@
 	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return $this
 	 */
-	public function add{{ singular|camelize }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
+	public function add{{ singular|stripLeadingUnderscore|camelize }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
 	{
 		if ($this->{{ name }} === null) {
 			$this->{{ name }} = {% if collectionType == 'array' %}[]{% else %}new {{ typeHint }}([]){% endif %};
@@ -21,7 +21,7 @@
 {% else %}
 		$this->{{ name }}[] = ${{ singular }};
 {% endif %}
-		$this->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
+		$this->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $this;
 	}

--- a/templates/element/method_get.twig
+++ b/templates/element/method_get.twig
@@ -6,7 +6,7 @@
 	 * @return {{ docBlockType ?? type }}{% if nullable %}|null{% endif %}
 
 	 */
-	public function get{{ name|camelize }}(){% if returnTypeHint %}: {{ nullableReturnTypeHint ?? returnTypeHint }}{% endif %}
+	public function get{{ name|stripLeadingUnderscore|camelize }}(){% if returnTypeHint %}: {{ nullableReturnTypeHint ?? returnTypeHint }}{% endif %}
 
 	{
 {% if collection %}
@@ -33,7 +33,7 @@
 	 * @throws \RuntimeException If value with this key is not set.
 {% endif %}
 	 */
-	public function get{{ singular|camelize }}($key){% if singularReturnTypeHint %}: {{ singularNullableReturnTypeHint ?? singularReturnTypeHint }}{% endif %}
+	public function get{{ singular|stripLeadingUnderscore|camelize }}($key){% if singularReturnTypeHint %}: {{ singularNullableReturnTypeHint ?? singularReturnTypeHint }}{% endif %}
 
 	{
 {% if singularNullable %}

--- a/templates/element/method_get_or_fail.twig
+++ b/templates/element/method_get_or_fail.twig
@@ -7,7 +7,7 @@
 	 *
 	 * @return {{ docBlockType ?? type }}
 	 */
-	public function get{{ name|camelize }}OrFail(){% if returnTypeHint %}: {{ returnTypeHint }}{% endif %}
+	public function get{{ name|stripLeadingUnderscore|camelize }}OrFail(){% if returnTypeHint %}: {{ returnTypeHint }}{% endif %}
 
 	{
 		if ($this->{{ name }} === null) {

--- a/templates/element/method_has.twig
+++ b/templates/element/method_has.twig
@@ -5,7 +5,7 @@
 {% endif %}
 	 * @return bool
 	 */
-	public function has{{ name|camelize }}(): bool
+	public function has{{ name|stripLeadingUnderscore|camelize }}(): bool
 	{
 {% if collectionType %}
 		if ($this->{{ name }} === null) {
@@ -32,7 +32,7 @@
 	 * @param {{ keyType }} $key
 	 * @return bool
 	 */
-	public function has{{ singular|camelize }}($key): bool
+	public function has{{ singular|stripLeadingUnderscore|camelize }}($key): bool
 	{
 		return isset($this->{{ name }}[$key]);
 	}

--- a/templates/element/method_set.twig
+++ b/templates/element/method_set.twig
@@ -7,10 +7,10 @@
 	 *
 	 * @return $this
 	 */
-	public function set{{ name|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if nullable %} = null{% endif %})
+	public function set{{ name|stripLeadingUnderscore|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if nullable %} = null{% endif %})
 	{
 		$this->{{ name }} = ${{ name }};
-		$this->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
+		$this->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $this;
 	}

--- a/templates/element/method_set_or_fail.twig
+++ b/templates/element/method_set_or_fail.twig
@@ -11,7 +11,7 @@
 	 *
 	 * @return $this
 	 */
-	public function set{{ name|camelize }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
+	public function set{{ name|stripLeadingUnderscore|camelize }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
 	{
 {% if not typeHint %}
 		if (${{ name }} === null) {
@@ -19,7 +19,7 @@
 		}
 {% endif %}
 		$this->{{ name }} = ${{ name }};
-		$this->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
+		$this->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $this;
 	}

--- a/templates/element/method_with.twig
+++ b/templates/element/method_with.twig
@@ -7,11 +7,11 @@
 	 *
 	 * @return static
 	 */
-	public function with{{ name|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %})
+	public function with{{ name|stripLeadingUnderscore|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %})
 	{
 		$new = clone $this;
 		$new->{{ name }} = ${{ name }};
-		$new->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
+		$new->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $new;
 	}

--- a/templates/element/method_with_added.twig
+++ b/templates/element/method_with_added.twig
@@ -10,7 +10,7 @@
 	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ singular|camelize }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
+	public function withAdded{{ singular|stripLeadingUnderscore|camelize }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }})
 	{
 		$new = clone $this;
 
@@ -23,7 +23,7 @@
 {% else %}
 		$new->{{ name }}[] = ${{ singular }};
 {% endif %}
-		$new->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
+		$new->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $new;
 	}

--- a/templates/element/method_with_or_fail.twig
+++ b/templates/element/method_with_or_fail.twig
@@ -11,7 +11,7 @@
 	 *
 	 * @return static
 	 */
-	public function with{{ name|camelize }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
+	public function with{{ name|stripLeadingUnderscore|camelize }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }})
 	{
 {% if not typeHint %}
 		if (${{ name }} === null) {
@@ -20,7 +20,7 @@
 {% endif %}
 		$new = clone $this;
 		$new->{{ name }} = ${{ name }};
-		$new->_touchedFields[static::FIELD_{{ name | camelize | underscore | upper }}] = true;
+		$new->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $new;
 	}

--- a/templates/element/optimizations.twig
+++ b/templates/element/optimizations.twig
@@ -10,7 +10,7 @@
 	 */
 	protected static array $_setters = [
 {% for field in fields %}
-		'{{ field.name }}' => '{% if immutable %}with{% else %}set{% endif %}{{ field.name | camelize }}',
+		'{{ field.name }}' => '{% if immutable %}with{% else %}set{% endif %}{{ field.name | stripLeadingUnderscore | camelize }}',
 {% endfor %}
 	];
 


### PR DESCRIPTION
## Summary
- Fixes generated method and constant names for underscore-prefixed fields like `_joinData` and `_matchingData`
- Adds `stripLeadingUnderscore` filter to generate proper camelCase names
- Adds documentation for CakePHP special fields

### Before
```php
// Field: _matchingData
$dto->get_matchingData();
$dto->with_matchingData($data);
UserDto::FIELD__MATCHING_DATA;  // double underscore
```

### After
```php
// Field: _matchingData
$dto->getMatchingData();
$dto->withMatchingData($data);
UserDto::FIELD_MATCHING_DATA;  // single underscore
```

This is needed for CakePHP's `projectAs()` feature which uses `_joinData` (BelongsToMany pivot data) and `_matchingData` (matching query results).

Related to #51 which added support for underscore-prefixed field names.