### PR TITLE
Add JsonSerializable support

### DIFF
--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -56,14 +56,6 @@ abstract class Dto implements Serializable, JsonSerializable
     protected static $collectionFactory = null;
 
     /**
-     * Default key type for JSON serialization. Can be set globally.
-     * If null, uses $defaultKeyType (which defaults to camelCase).
-     *
-     * @var string|null
-     */
-    protected static ?string $defaultJsonKeyType = null;
-
-    /**
      * Set the default key type for all DTOs.
      *
      * @param string|null $type One of TYPE_DEFAULT, TYPE_CAMEL, TYPE_UNDERSCORED, TYPE_DASHED
@@ -102,36 +94,13 @@ abstract class Dto implements Serializable, JsonSerializable
     }
 
     /**
-     * Set the default key type for JSON serialization.
-     * This affects the output of jsonSerialize() and json_encode($dto).
-     *
-     * @param string|null $type One of TYPE_DEFAULT, TYPE_CAMEL, TYPE_UNDERSCORED, TYPE_DASHED, or null to use $defaultKeyType
-     *
-     * @return void
-     */
-    public static function setDefaultJsonKeyType(?string $type): void
-    {
-        static::$defaultJsonKeyType = $type;
-    }
-
-    /**
-     * Get the default key type for JSON serialization.
-     *
-     * @return string|null
-     */
-    public static function getDefaultJsonKeyType(): ?string
-    {
-        return static::$defaultJsonKeyType;
-    }
-
-    /**
      * Specify data which should be serialized to JSON.
      *
      * @return array<string, mixed>
      */
     public function jsonSerialize(): array
     {
-        return $this->toArray(static::$defaultJsonKeyType);
+        return $this->toArray();
     }
 
     /**

--- a/tests/Dto/DtoTest.php
+++ b/tests/Dto/DtoTest.php
@@ -34,7 +34,6 @@ class DtoTest extends TestCase
     {
         parent::tearDown();
         Dto::setDefaultKeyType(null);
-        Dto::setDefaultJsonKeyType(null);
         Dto::setCollectionFactory(null);
     }
 
@@ -1210,50 +1209,9 @@ class DtoTest extends TestCase
         $this->assertSame('Nested', $decoded['simple']['name']);
     }
 
-    public function testDefaultJsonKeyType(): void
+    public function testJsonSerializeRespectsDefaultKeyType(): void
     {
-        Dto::setDefaultJsonKeyType(Dto::TYPE_UNDERSCORED);
-
-        $this->assertSame(Dto::TYPE_UNDERSCORED, Dto::getDefaultJsonKeyType());
-    }
-
-    public function testJsonSerializeWithDefaultJsonKeyType(): void
-    {
-        Dto::setDefaultJsonKeyType(Dto::TYPE_UNDERSCORED);
-
-        $dto = new CollectionDto([
-            'arrayItems' => [
-                ['name' => 'Item 1'],
-            ],
-        ]);
-
-        $json = json_encode($dto);
-        $decoded = json_decode($json, true);
-
-        $this->assertArrayHasKey('array_items', $decoded);
-    }
-
-    public function testJsonSerializeWithDashedKeyType(): void
-    {
-        Dto::setDefaultJsonKeyType(Dto::TYPE_DASHED);
-
-        $dto = new CollectionDto([
-            'arrayItems' => [
-                ['name' => 'Item 1'],
-            ],
-        ]);
-
-        $json = json_encode($dto);
-        $decoded = json_decode($json, true);
-
-        $this->assertArrayHasKey('array-items', $decoded);
-    }
-
-    public function testJsonSerializeIndependentOfDefaultKeyType(): void
-    {
-        // Set different defaults for general use vs JSON
         Dto::setDefaultKeyType(Dto::TYPE_UNDERSCORED);
-        Dto::setDefaultJsonKeyType(Dto::TYPE_DASHED);
 
         $dto = new CollectionDto([
             'array_items' => [
@@ -1261,29 +1219,6 @@ class DtoTest extends TestCase
             ],
         ]);
 
-        // toArray() uses defaultKeyType (underscored)
-        $array = $dto->toArray();
-        $this->assertArrayHasKey('array_items', $array);
-
-        // jsonSerialize() uses defaultJsonKeyType (dashed)
-        $json = json_encode($dto);
-        $decoded = json_decode($json, true);
-        $this->assertArrayHasKey('array-items', $decoded);
-    }
-
-    public function testJsonSerializeUsesDefaultKeyTypeWhenJsonKeyTypeIsNull(): void
-    {
-        Dto::setDefaultKeyType(Dto::TYPE_UNDERSCORED);
-        Dto::setDefaultJsonKeyType(null);
-
-        $dto = new CollectionDto([
-            'array_items' => [
-                ['name' => 'Item 1'],
-            ],
-        ]);
-
-        // When defaultJsonKeyType is null, jsonSerialize passes null to toArray,
-        // which then uses defaultKeyType
         $json = json_encode($dto);
         $decoded = json_decode($json, true);
 


### PR DESCRIPTION
## Summary

- DTOs now implement `JsonSerializable`, allowing direct use with `json_encode($dto)`
- Uses `toArray()` internally, so it respects the existing `setDefaultKeyType()` setting

## Usage

```php
// json_encode() now works directly on DTOs
$dto = new UserDto(['firstName' => 'John', 'lastName' => 'Doe']);
$json = json_encode($dto); // {"firstName":"John","lastName":"Doe"}

// Respects global default key type
Dto::setDefaultKeyType(Dto::TYPE_UNDERSCORED);
$json = json_encode($dto); // {"first_name":"John","last_name":"Doe"}
```