### PR TITLE
Fix XML injection and remove unused generated code

### DIFF
--- a/src/Importer/Builder/SchemaBuilder.php
+++ b/src/Importer/Builder/SchemaBuilder.php
@@ -114,9 +114,10 @@ class SchemaBuilder implements BuilderInterface
 
         $fieldsStr = implode("\n", $fieldLines);
         $extendsAttr = $extends ? ' extends="' . $this->escapeXml($extends) . '"' : '';
+        $escapedName = $this->escapeXml($name);
 
         return <<<XML
-	<dto name="{$name}"{$extendsAttr}>
+	<dto name="{$escapedName}"{$extendsAttr}>
 {$fieldsStr}
 	</dto>
 XML;

--- a/templates/element/optimizations.twig
+++ b/templates/element/optimizations.twig
@@ -13,17 +13,6 @@
 	protected const HAS_FAST_PATH = true;
 
 	/**
-	 * Pre-computed setter method names for fast lookup.
-	 *
-	 * @var array<string, string>
-	 */
-	protected static array $_setters = [
-{% for field in fields %}
-		'{{ field.name }}' => '{% if immutable %}with{% else %}set{% endif %}{{ field.name | stripLeadingUnderscore | camelize }}',
-{% endfor %}
-	];
-
-	/**
 	 * Optimized array assignment without dynamic method calls.
 	 *
 	 * @param array<string, mixed> $data


### PR DESCRIPTION
## Summary
- Escape DTO name in XML output to prevent potential injection via external schemas (Importer)
- Remove unused `$_setters` array from `optimizations.twig` template (dead code)

## Details

**XML Injection Fix** (`SchemaBuilder.php:117-120`)
The Importer's SchemaBuilder generates XML from external sources (JSON Schema, OpenAPI). DTO names from `title` properties weren't escaped, allowing potential XML injection. Now uses `escapeXml()` consistently.

**Dead Code Removal** (`optimizations.twig`)
The `$_setters` array was pre-computed but never used. The fast-path methods assign directly to properties, bypassing setters entirely - that's what makes them fast. This array was unused overhead in every generated DTO.