### PR TITLE
Fix immutable array copy and collection key field fallback

### DIFF
--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -776,6 +776,8 @@ abstract class Dto implements Serializable, JsonSerializable
      * @param string|int $index
      * @param string|bool $key
      *
+     * @throws \RuntimeException If key field is specified but not present in element.
+     *
      * @return array
      */
     protected function addValueToArrayCollection(array $collection, $element, $arrayElement, $index, $key): array
@@ -791,8 +793,15 @@ abstract class Dto implements Serializable, JsonSerializable
             return $collection;
         }
 
-        if (is_array($arrayElement) && isset($arrayElement[$key])) {
+        if (is_array($arrayElement) && array_key_exists($key, $arrayElement)) {
             $index = $arrayElement[$key];
+        } elseif (is_array($arrayElement)) {
+            throw new RuntimeException(sprintf(
+                'Key field `%s` not found in collection element at index `%s`. '
+                . 'Either ensure all elements have this field or remove the key configuration.',
+                $key,
+                $index,
+            ));
         }
 
         $collection[(string)$index] = $element;

--- a/templates/element/method_with.twig
+++ b/templates/element/method_with.twig
@@ -10,7 +10,11 @@
 	public function with{{ name|stripLeadingUnderscore|camelize }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %})
 	{
 		$new = clone $this;
+{% if isArray or typeHint == 'array' %}
+		$new->{{ name }} = ${{ name }} !== null ? $new->cloneArray(${{ name }}) : null;
+{% else %}
 		$new->{{ name }} = ${{ name }};
+{% endif %}
 		$new->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $new;

--- a/templates/element/method_with_or_fail.twig
+++ b/templates/element/method_with_or_fail.twig
@@ -19,7 +19,11 @@
 		}
 {% endif %}
 		$new = clone $this;
+{% if isArray or typeHint == 'array' %}
+		$new->{{ name }} = $new->cloneArray(${{ name }});
+{% else %}
 		$new->{{ name }} = ${{ name }};
+{% endif %}
 		$new->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | camelize | underscore | upper }}] = true;
 
 		return $new;

--- a/tests/Dto/DtoTest.php
+++ b/tests/Dto/DtoTest.php
@@ -1371,4 +1371,36 @@ class DtoTest extends TestCase
 
         $this->assertContains('items', $updated->touchedFields());
     }
+
+    public function testImmutableWithArrayDoesDefensiveCopy(): void
+    {
+        $dto = new ImmutableCollectionDto();
+        $originalArray = [
+            SimpleDto::create(['name' => 'Item 1']),
+            SimpleDto::create(['name' => 'Item 2']),
+        ];
+
+        $updated = $dto->withArrayItems($originalArray);
+
+        // Modify original array after passing to withArrayItems
+        $originalArray[0] = SimpleDto::create(['name' => 'Modified']);
+
+        // Updated DTO should NOT be affected by changes to original array
+        $items = $updated->getArrayItems();
+        $this->assertSame('Item 1', $items[0]->getName());
+    }
+
+    public function testCollectionKeyFieldMissingThrowsException(): void
+    {
+        // Try to create associative collection where key field is missing
+        // associativeItems uses 'name' as key field
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Key field `name` not found in collection element');
+
+        new AdvancedDto([
+            'associativeItems' => [
+                ['count' => 5], // Missing 'name' field which is configured as key
+            ],
+        ]);
+    }
 }

--- a/tests/TestDto/ImmutableCollectionDto.php
+++ b/tests/TestDto/ImmutableCollectionDto.php
@@ -164,7 +164,8 @@ class ImmutableCollectionDto extends AbstractImmutableDto
     public function withArrayItems(array $arrayItems): static
     {
         $new = clone $this;
-        $new->arrayItems = $arrayItems;
+        // Defensive copy to prevent external modification breaking immutability
+        $new->arrayItems = $new->cloneArray($arrayItems);
         $new->_touchedFields['arrayItems'] = true;
 
         return $new;


### PR DESCRIPTION
## Summary

- Fix immutable `with*` methods to perform defensive array copying
- Fix collection key field to throw exception when missing instead of silent fallback

## Details

**Immutable Array Copy** (`method_with.twig`, `method_with_or_fail.twig`)

Previously, immutable DTOs' `with*` methods for array fields directly assigned the passed array, creating a shared reference that broke immutability since external code could modify the original array after passing it.

Now arrays are defensively copied using `cloneArray()`.

**Collection Key Field** (`Dto.php:796-805`)

Previously, when a collection was configured with a key field (e.g., `key="slug"`) but an element didn't have that field, it silently fell back to using the numeric index. This could cause subtle bugs.

Now it throws `RuntimeException` with a clear message indicating which key field is missing and at which index.