### PR TITLE
Refactor Builder.php into smaller focused classes

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace PhpCollective\Dto\Generator;
 
-use InvalidArgumentException;
-use PhpCollective\Dto\Dto\AbstractDto;
-use PhpCollective\Dto\Dto\AbstractImmutableDto;
 use PhpCollective\Dto\Engine\EngineInterface;
 use PhpCollective\Dto\Engine\FileBasedEngineInterface;
-use PhpCollective\Dto\Utility\Inflector;
-use ReflectionClass;
-use ReflectionException;
 use RuntimeException;
 
+/**
+ * Builds DTO definitions from configuration files.
+ */
 class Builder
 {
     /**
@@ -41,9 +38,19 @@ class Builder
     protected TypeValidator $typeValidator;
 
     /**
-     * @var \PhpCollective\Dto\Generator\TypeResolver
+     * @var \PhpCollective\Dto\Generator\DtoValidator
      */
-    protected TypeResolver $typeResolver;
+    protected DtoValidator $dtoValidator;
+
+    /**
+     * @var \PhpCollective\Dto\Generator\FieldCompletor
+     */
+    protected FieldCompletor $fieldCompletor;
+
+    /**
+     * @var \PhpCollective\Dto\Generator\ExtendsResolver
+     */
+    protected ExtendsResolver $extendsResolver;
 
     /**
      * @var \PhpCollective\Dto\Generator\ArrayShapeBuilder
@@ -58,7 +65,7 @@ class Builder
     /**
      * Needed for Dto to work dynamically.
      *
-     * @var array
+     * @var array<string>
      */
     protected array $metaDataKeys = [
         'name',
@@ -95,11 +102,20 @@ class Builder
         }
 
         $this->typeValidator = new TypeValidator();
-        $this->typeResolver = new TypeResolver(
+        $typeResolver = new TypeResolver(
             $this->typeValidator,
             (bool)$this->config['scalarAndReturnTypes'],
         );
         $this->arrayShapeBuilder = new ArrayShapeBuilder($this->config['suffix']);
+
+        $this->dtoValidator = new DtoValidator($this->typeValidator);
+        $this->fieldCompletor = new FieldCompletor(
+            $this->typeValidator,
+            $typeResolver,
+            $this->arrayShapeBuilder,
+            $this->config,
+        );
+        $this->extendsResolver = new ExtendsResolver($this->config['suffix']);
         $this->dependencyAnalyzer = new DependencyAnalyzer($this->config['suffix']);
     }
 
@@ -115,17 +131,19 @@ class Builder
     public function getConfigOrFail(string $key): mixed
     {
         if (!array_key_exists($key, $this->config)) {
-            throw new RuntimeException("Configuration key '{$key}' not found");
+            throw new RuntimeException("Configuration key `{$key}` not found");
         }
 
         return $this->config[$key];
     }
 
     /**
+     * Build DTO definitions from configuration path.
+     *
      * @param string $configPath
      * @param array<string, mixed> $options
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function build(string $configPath, array $options = []): array
     {
@@ -133,11 +151,29 @@ class Builder
             'plugin' => null,
             'namespace' => null,
         ];
-        $namespace = $this->_getNamespace($options['namespace'], $options['plugin']);
+        $namespace = $this->getNamespace($options['namespace'], $options['plugin']);
 
-        $files = $this->_getFiles($configPath);
+        $files = $this->getFiles($configPath);
+        $config = $this->parseFiles($files);
+        $result = $this->mergeConfigs($config);
 
+        // Detect circular dependencies before processing
+        $this->dependencyAnalyzer->analyze($result);
+
+        return $this->createDtos($result, $namespace);
+    }
+
+    /**
+     * Parse configuration files.
+     *
+     * @param array<string> $files
+     *
+     * @return array<string, mixed>
+     */
+    protected function parseFiles(array $files): array
+    {
         $config = [];
+
         foreach ($files as $file) {
             if ($this->engine instanceof FileBasedEngineInterface) {
                 $config[$file] = $this->engine->parseFile($file);
@@ -147,28 +183,24 @@ class Builder
             }
         }
 
-        $result = $this->_merge($config);
-
-        // Detect circular dependencies before processing
-        $this->dependencyAnalyzer->analyze($result);
-
-        return $this->_createDtos($result, $namespace);
+        return $config;
     }
 
     /**
+     * Create DTOs from merged configuration.
+     *
      * @param array<string, mixed> $config
      * @param string $namespace
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return array
+     * @return array<string, mixed>
      */
-    protected function _createDtos(array $config, string $namespace): array
+    protected function createDtos(array $config, string $namespace): array
     {
+        // Phase 1: Validate and complete each DTO
         foreach ($config as $name => $dto) {
-            $this->_validateDto($dto);
-            $dto = $this->_complete($dto, $namespace);
-            $dto = $this->_completeMeta($dto, $namespace);
+            $this->dtoValidator->validate($dto);
+            $dto = $this->fieldCompletor->complete($dto, $namespace);
+            $dto = $this->fieldCompletor->completeMeta($dto, $namespace);
 
             $dto += [
                 'immutable' => $this->config['immutable'],
@@ -178,7 +210,6 @@ class Builder
                 'traits' => [],
             ];
 
-            // Normalize traits to array format
             $dto['traits'] = $this->normalizeTraits($dto['traits']);
 
             if (!empty($dto['immutable']) && $dto['extends'] === '\\PhpCollective\\Dto\\Dto\\AbstractDto') {
@@ -188,249 +219,42 @@ class Builder
             $config[$name] = $dto;
         }
 
+        // Phase 2: Resolve extends references
+        $config = $this->extendsResolver->resolve($config);
+
+        // Phase 3: Merge base config into DTOs with extends
         foreach ($config as $name => $dto) {
-            if (in_array($dto['extends'], ['\\PhpCollective\\Dto\\Dto\\AbstractDto', '\\PhpCollective\\Dto\\Dto\\AbstractImmutableDto'], true)) {
-                continue;
-            }
-
-            $extendedDto = $dto['extends'];
-            $isImmutable = !empty($dto['immutable']);
-
-            if (isset($config[$extendedDto])) {
-                $config[$name]['extends'] = $extendedDto . $this->getConfigOrFail('suffix');
-                if (!$isImmutable && !empty($config[$extendedDto]['immutable'])) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'extends' attribute for '%s' DTO: cannot extend immutable DTO '%s'.\n"
-                        . "Hint: Either make '%s' immutable, or extend a mutable DTO instead.",
-                        $dto['name'],
-                        $dto['extends'],
-                        $dto['name'],
-                    ));
-                }
-                if ($isImmutable && empty($config[$extendedDto]['immutable'])) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'extends' attribute for '%s' DTO: immutable DTO cannot extend mutable DTO '%s'.\n"
-                        . "Hint: Either make '%s' mutable, or make '%s' immutable.",
-                        $dto['name'],
-                        $dto['extends'],
-                        $dto['name'],
-                        $dto['extends'],
-                    ));
-                }
-            } else {
-                try {
-                    $extendedDtoReflectionClass = new ReflectionClass($extendedDto);
-                } catch (ReflectionException $e) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'extends' attribute for '%s' DTO: class '%s' does not exist.\n"
-                        . 'Hint: Check the class name spelling and ensure the class is autoloadable.',
-                        $dto['name'],
-                        $dto['extends'],
-                    ));
-                }
-
-                if ($extendedDtoReflectionClass->getParentClass() === false) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'extends' attribute for '%s' DTO: '%s' must extend %s.\n"
-                        . 'Hint: The parent class should be a DTO class extending the appropriate base.',
-                        $dto['name'],
-                        $dto['extends'],
-                        $isImmutable ? AbstractImmutableDto::class : AbstractDto::class,
-                    ));
-                }
-                if ($isImmutable && !$extendedDtoReflectionClass->isSubclassOf(AbstractImmutableDto::class)) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'extends' attribute for '%s' DTO: '%s' is not immutable.\n"
-                        . 'Hint: Immutable DTOs must extend other immutable DTOs or AbstractImmutableDto.',
-                        $dto['name'],
-                        $dto['extends'],
-                    ));
-                }
-                if (!$isImmutable && !$extendedDtoReflectionClass->isSubclassOf(AbstractDto::class)) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'extends' attribute for '%s' DTO: '%s' is immutable.\n"
-                        . "Hint: Mutable DTOs cannot extend immutable DTOs. Either make '%s' immutable or change the parent.",
-                        $dto['name'],
-                        $dto['extends'],
-                        $dto['name'],
-                    ));
-                }
-            }
-
             $config[$name] += $this->config;
         }
 
-        foreach ($config as $name => $dto) {
-            if (strpos($dto['className'], '/') !== false) {
-                $pieces = explode('/', $dto['className']);
-                $dto['className'] = array_pop($pieces);
-                $dto['namespace'] .= '\\' . implode('\\', $pieces);
-            }
-            if (!empty($dto['extends']) && strpos($dto['extends'], '/') !== false) {
-                $pieces = explode('/', $dto['extends']);
-                $dto['extends'] = '\\' . $namespace . '\Dto\\' . implode('\\', $pieces);
-            }
+        // Phase 4: Resolve namespace paths
+        $config = $this->extendsResolver->resolveNamespacePaths($config, $namespace);
 
-            $config[$name] = $dto;
-        }
-
-        // Add shaped array types for toArray()/createFromArray() PHPDoc
+        // Phase 5: Add array shapes for PHPDoc
         foreach ($config as $name => $dto) {
             $config[$name]['arrayShape'] = $this->arrayShapeBuilder->buildArrayShape($dto['fields'], $config, $dto);
+            $config[$name]['metaData'] = $this->metaData($dto['fields']);
         }
 
         return $config;
     }
 
     /**
-     * @param array<string, mixed> $dto
+     * Merge multiple configuration arrays.
      *
-     * @throws \InvalidArgumentException
+     * @param array<string, mixed> $configs
      *
-     * @return void
+     * @return array<string, mixed>
      */
-    protected function _validateDto(array $dto): void
-    {
-        if (empty($dto['name'])) {
-            throw new InvalidArgumentException(
-                "DTO name missing, but required.\n"
-                . 'Hint: Each DTO definition must have a "name" attribute.',
-            );
-        }
-        $dtoName = $dto['name'];
-        if (!$this->typeValidator->isValidDto($dtoName)) {
-            throw new InvalidArgumentException(sprintf(
-                "Invalid DTO name '%s'.\n"
-                . 'Hint: DTO names must be PascalCase starting with uppercase letter (e.g., "UserProfile", "OrderItem").',
-                $dtoName,
-            ));
-        }
-
-        $fields = $dto['fields'];
-
-        foreach ($fields as $name => $array) {
-            if (empty($array['name'])) {
-                throw new InvalidArgumentException(sprintf(
-                    "Field attribute 'name' missing for field '%s' in '%s' DTO.\n"
-                    . 'Hint: Each field must have a "name" attribute.',
-                    $name,
-                    $dtoName,
-                ));
-            }
-            if (empty($array['type'])) {
-                throw new InvalidArgumentException(sprintf(
-                    "Field attribute 'type' missing for field '%s' in '%s' DTO.\n"
-                    . 'Hint: Each field must have a "type" attribute (e.g., "string", "int", "ItemDto[]").',
-                    $name,
-                    $dtoName,
-                ));
-            }
-            foreach ($array as $key => $value) {
-                $expected = Inflector::variable(Inflector::underscore($key));
-                if ($key !== $expected) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid field attribute '%s' for field '%s' in '%s' DTO.\n"
-                        . "Hint: Expected '%s' (camelCase format).",
-                        $key,
-                        $name,
-                        $dtoName,
-                        $expected,
-                    ));
-                }
-            }
-
-            if (!$this->typeValidator->isValidName($array['name'])) {
-                throw new InvalidArgumentException(sprintf(
-                    "Invalid field name '%s' in '%s' DTO.\n"
-                    . 'Hint: Field names must be alphanumeric starting with a letter (e.g., "userName", "itemCount").',
-                    $array['name'],
-                    $dtoName,
-                ));
-            }
-            if (!$this->typeValidator->isValidType($array['type'])) {
-                throw new InvalidArgumentException(sprintf(
-                    "Invalid type '%s' for field '%s' in '%s' DTO.\n"
-                    . 'Hint: Valid types include: scalar types (int, string, bool, float), '
-                    . 'DTO references (OtherDto), arrays (string[], OtherDto[]), '
-                    . 'or fully qualified class names (\\App\\MyClass).',
-                    $array['type'],
-                    $name,
-                    $dtoName,
-                ));
-            }
-
-            if (!empty($array['collection'])) {
-                if (!$this->typeValidator->isValidArray($array['type']) || !$this->typeValidator->isValidCollection($array['type'])) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid collection type '%s' for field '%s' in '%s' DTO.\n"
-                        . 'Hint: Collection types must use array notation (e.g., "string[]", "ItemDto[]").',
-                        $array['type'],
-                        $name,
-                        $dtoName,
-                    ));
-                }
-            }
-
-            if (!empty($array['singular'])) {
-                $expected = Inflector::variable(Inflector::underscore($array['singular']));
-                if ($array['singular'] !== $expected) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid singular name '%s' for field '%s' in '%s' DTO.\n"
-                        . "Hint: Expected '%s' (camelCase format).",
-                        $array['singular'],
-                        $name,
-                        $dtoName,
-                        $expected,
-                    ));
-                }
-
-                if (isset($array['collection']) && $array['collection'] === false) {
-                    throw new InvalidArgumentException(sprintf(
-                        "Invalid 'singular' attribute for non-collection field '%s' in '%s' DTO.\n"
-                        . 'Hint: The "singular" attribute is only valid for collection fields.',
-                        $name,
-                        $dtoName,
-                    ));
-                }
-            }
-        }
-
-        // Check for method name collisions between underscore-prefixed and non-prefixed fields
-        // e.g., '_foo' and 'foo' would both generate 'getFoo()', 'setFoo()', etc.
-        $methodNames = [];
-        foreach ($fields as $array) {
-            $fieldName = $array['name'];
-            $methodName = Inflector::camelize($fieldName);
-
-            if (isset($methodNames[$methodName])) {
-                throw new InvalidArgumentException(sprintf(
-                    "Field name collision in '%s' DTO: fields '%s' and '%s' would generate identical method names.\n"
-                    . "Hint: Both fields would generate methods like 'get%s()', 'set%s()', etc. Use only one of these field names.",
-                    $dtoName,
-                    $methodNames[$methodName],
-                    $fieldName,
-                    $methodName,
-                    $methodName,
-                ));
-            }
-            $methodNames[$methodName] = $fieldName;
-        }
-    }
-
-    /**
-     * @param array<array<string, mixed>> $configs
-     *
-     * @return array
-     */
-    protected function _merge(array $configs): array
+    protected function mergeConfigs(array $configs): array
     {
         $result = [];
+
         foreach ($configs as $config) {
             $result += $config;
 
             foreach ($config as $name => $dto) {
-                $this->validateMerge($result[$name], $dto);
-
+                $this->dtoValidator->validateMerge($result[$name], $dto);
                 $result[$name] += $dto;
             }
         }
@@ -439,345 +263,16 @@ class Builder
     }
 
     /**
-     * @param array<string, mixed> $dto
-     * @param string $namespace
+     * Get configuration files from path.
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return array
-     */
-    protected function _complete(array $dto, string $namespace): array
-    {
-        $dtoName = $dto['name'];
-        $fields = $dto['fields'];
-        foreach ($fields as $field => $data) {
-            $data += [
-                'required' => false,
-                'defaultValue' => null,
-                'nullable' => empty($data['required']),
-                'returnTypeHint' => null,
-                'nullableTypeHint' => null,
-                'isArray' => false,
-                'dto' => null,
-                'collection' => !empty($data['singular']),
-                'collectionType' => null,
-                'associative' => false,
-                'key' => null,
-                'deprecated' => null,
-                'serialize' => null,
-                'factory' => null,
-                'mapFrom' => null,
-                'mapTo' => null,
-                'transformFrom' => null,
-                'transformTo' => null,
-            ];
-            if ($data['required']) {
-                $data['nullable'] = false;
-            }
-
-            $fields[$field] = $data;
-        }
-
-        foreach ($fields as $key => $field) {
-            if ($this->typeValidator->isValidSimpleType($field['type'], $this->typeValidator->getSimpleTypeAdditionsForDocBlock())) {
-                continue;
-            }
-            if ($this->typeValidator->isValidDto($field['type'])) {
-                $fields[$key]['dto'] = $field['type'];
-
-                continue;
-            }
-            if ($this->isCollection($field)) {
-                $fields[$key]['collection'] = true;
-                $fields[$key]['collectionType'] = $this->typeResolver->collectionType($field, $this->config['defaultCollectionType']);
-                $fields[$key]['nullable'] = false;
-
-                $fields[$key] = $this->_completeCollectionSingular($fields[$key], $dtoName, $namespace, $fields);
-                $fields[$key]['singularNullable'] = substr($fields[$key]['type'], 0, 1) === '?';
-
-                if (!empty($fields[$key]['singular'])) {
-                    $singular = $fields[$key]['singular'];
-                    if (!empty($fields[$singular])) {
-                        throw new InvalidArgumentException(sprintf(
-                            "Invalid singular name '%s' for collection field '%s' in '%s' DTO.\n"
-                            . "Hint: The singular name conflicts with existing field '%s'. Use a different singular name.",
-                            $singular,
-                            $key,
-                            $dtoName,
-                            $singular,
-                        ));
-                    }
-                }
-
-                if (preg_match('#^([A-Z][a-zA-Z/]+)\[\]$#', $field['type'], $matches)) {
-                    $fields[$key]['type'] = $this->typeResolver->dtoTypeToClass($matches[1], $namespace, $this->getConfigOrFail('suffix')) . '[]';
-                }
-
-                if ($fields[$key]['singularNullable']) {
-                    $fields[$key]['type'] = '(' . $fields[$key]['singularType'] . '|null)[]';
-                }
-
-                continue;
-            }
-            if ($this->typeValidator->isValidArray($field['type'])) {
-                $fields[$key]['isArray'] = true;
-                if (preg_match('#^([A-Z][a-zA-Z/]+)\[\]$#', $field['type'], $matches)) {
-                    $fields[$key]['type'] = $this->typeResolver->dtoTypeToClass($matches[1], $namespace, $this->getConfigOrFail('suffix')) . '[]';
-                }
-
-                continue;
-            }
-
-            if ($this->typeValidator->isValidInterfaceOrClass($field['type'])) {
-                $fields[$key]['isClass'] = true;
-
-                if (empty($fields[$key]['serialize'])) {
-                    $fields[$key]['serialize'] = $this->typeResolver->detectSerialize($fields[$key]);
-                }
-
-                $fields[$key]['enum'] = $this->typeResolver->enumType($field['type']);
-
-                continue;
-            }
-
-            throw new InvalidArgumentException(sprintf(
-                "Invalid type '%s' for field '%s' in '%s' DTO.\n"
-                . 'Hint: Valid types include: scalar types (int, string, bool, float), '
-                . 'DTO references (OtherDto), arrays (string[], OtherDto[]), '
-                . 'or fully qualified class names (\\App\\MyClass).',
-                $field['type'],
-                $key,
-                $dtoName,
-            ));
-        }
-
-        $dto['fields'] = $fields;
-
-        return $dto;
-    }
-
-    /**
-     * @param array<string, mixed> $field
-     *
-     * @return bool
-     */
-    protected function isCollection(array $field): bool
-    {
-        if (!$field['collection'] && !$field['collectionType'] && !$field['associative']) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     * @param string $dtoName
-     * @param string $namespace
-     * @param array<string, mixed> $fields
-     *
-     * @throws \InvalidArgumentException
-     *
-     * @return array
-     */
-    protected function _completeCollectionSingular(array $data, string $dtoName, string $namespace, array $fields): array
-    {
-        $fieldName = $data['name'];
-        if (!$data['collection'] && empty($data['collectionType'])) {
-            return $data;
-        }
-
-        $data['singularType'] = $this->typeResolver->singularType($data['type']);
-        if ($data['singularType'] && $this->typeValidator->isValidDto($data['singularType'])) {
-            $data['singularType'] = $this->typeResolver->dtoTypeToClass($data['singularType'], $namespace, $this->getConfigOrFail('suffix'));
-            $data['singularClass'] = $data['singularType'];
-        }
-
-        if (!empty($data['singular'])) {
-            return $data;
-        }
-
-        $singular = Inflector::singularize($fieldName);
-        if ($singular === $fieldName) {
-            throw new InvalidArgumentException(sprintf(
-                "Cannot auto-singularize field name '%s' in '%s' DTO.\n"
-                . "Hint: The field name '%s' has no singular form. Add an explicit 'singular' attribute (e.g., singular=\"%sItem\").",
-                $fieldName,
-                $dtoName,
-                $fieldName,
-                $fieldName,
-            ));
-        }
-        // Collision detection - throw exception instead of silent failure
-        if (!empty($fields[$singular])) {
-            throw new InvalidArgumentException(sprintf(
-                "Auto-generated singular '%s' for collection field '%s' in '%s' DTO collides with existing field.\n"
-                . "Hint: Add an explicit 'singular' attribute with a unique name to avoid this collision.",
-                $singular,
-                $fieldName,
-                $dtoName,
-            ));
-        }
-
-        $data['singular'] = $singular;
-
-        return $data;
-    }
-
-    /**
-     * @param array<string, mixed> $dto
-     * @param string $namespace
-     *
-     * @return array
-     */
-    protected function _completeMeta(array $dto, string $namespace): array
-    {
-        $fields = $dto['fields'];
-
-        foreach ($fields as $key => $field) {
-            if ($field['dto']) {
-                $className = $this->typeResolver->dtoTypeToClass($field['type'], $namespace, $this->getConfigOrFail('suffix'));
-                $fields[$key]['type'] = $className;
-                $fields[$key]['typeHint'] = $className;
-            } else {
-                $fields[$key]['typeHint'] = $field['type'];
-            }
-            $fields[$key]['typeHint'] = $this->typeResolver->typehint($fields[$key]['typeHint']);
-
-            if ($field['collection']) {
-                if ($field['collectionType'] === 'array') {
-                    $fields[$key]['typeHint'] = 'array';
-                    // Generic PHPDoc type for arrays: array<int, ElementType>
-                    $fields[$key]['docBlockType'] = $this->arrayShapeBuilder->buildGenericArrayType($field);
-                } else {
-                    $fields[$key]['typeHint'] = $field['collectionType'];
-
-                    $fields[$key]['type'] .= '|' . $fields[$key]['typeHint'];
-                    // Generic PHPDoc type for collections: \ArrayObject<int, ElementType>
-                    $fields[$key]['docBlockType'] = $this->arrayShapeBuilder->buildGenericCollectionType($field);
-                }
-            }
-            if ($field['isArray']) {
-                if ($field['type'] !== 'array') {
-                    $fields[$key]['typeHint'] = 'array';
-                    // Generic PHPDoc type for typed arrays: array<int, ElementType>
-                    $fields[$key]['docBlockType'] = $this->arrayShapeBuilder->buildGenericArrayType($field);
-                }
-            }
-
-            if ($fields[$key]['typeHint'] && $this->config['scalarAndReturnTypes']) {
-                $fields[$key]['returnTypeHint'] = $fields[$key]['typeHint'];
-
-                // Pre-compute nullable return type hint (for getters)
-                if ($fields[$key]['nullable']) {
-                    // For union types, use |null suffix instead of ? prefix
-                    if ($this->typeResolver->isUnionType($fields[$key]['typeHint'])) {
-                        $fields[$key]['nullableReturnTypeHint'] = $fields[$key]['typeHint'] . '|null';
-                    } else {
-                        $fields[$key]['nullableReturnTypeHint'] = '?' . $fields[$key]['typeHint'];
-                    }
-                }
-            }
-
-            if ($fields[$key]['typeHint'] && $this->config['scalarAndReturnTypes'] && $fields[$key]['nullable']) {
-                // For union types, use |null suffix instead of ? prefix
-                if ($this->typeResolver->isUnionType($fields[$key]['typeHint'])) {
-                    $fields[$key]['nullableTypeHint'] = $fields[$key]['typeHint'] . '|null';
-                } else {
-                    $fields[$key]['nullableTypeHint'] = '?' . $fields[$key]['typeHint'];
-                }
-            }
-
-            if ($fields[$key]['collection']) {
-                $fields[$key] += [
-                    'singularTypeHint' => null,
-                    'singularNullable' => false,
-                    'singularReturnTypeHint' => null,
-                    'singularNullableReturnTypeHint' => null,
-                ];
-                if ($fields[$key]['singularType']) {
-                    $fields[$key]['singularTypeHint'] = $this->typeResolver->typehint($fields[$key]['singularType']);
-                }
-
-                if ($fields[$key]['singularTypeHint'] && $this->config['scalarAndReturnTypes']) {
-                    $fields[$key]['singularReturnTypeHint'] = $fields[$key]['singularTypeHint'];
-
-                    // Pre-compute nullable singular return type hint for associative collections
-                    if ($fields[$key]['singularNullable']) {
-                        if ($this->typeResolver->isUnionType($fields[$key]['singularTypeHint'])) {
-                            $fields[$key]['singularNullableReturnTypeHint'] = $fields[$key]['singularTypeHint'] . '|null';
-                        } else {
-                            $fields[$key]['singularNullableReturnTypeHint'] = '?' . $fields[$key]['singularTypeHint'];
-                        }
-                    }
-                }
-
-                // Add key type for associative collections (string) vs indexed (int)
-                $fields[$key]['keyType'] = !empty($fields[$key]['associative']) ? 'string' : 'int';
-            }
-        }
-
-        $dto['fields'] = $fields;
-        $dto['metaData'] = $this->metaData($fields);
-
-        $dto += [
-            'deprecated' => null,
-        ];
-
-        return $dto;
-    }
-
-    /**
-     * @param array|null $existing
-     * @param array|null $new
-     *
-     * @throws \RuntimeException
-     *
-     * @return void
-     */
-    protected function validateMerge(?array $existing, ?array $new): void
-    {
-        if (!$existing || !$new) {
-            return;
-        }
-
-        $dtoName = $existing['name'] ?? 'unknown';
-
-        foreach ($existing as $field => $info) {
-            if (!isset($new[$field])) {
-                continue;
-            }
-            if (!isset($info['type'])) {
-                continue;
-            }
-            if (!isset($new[$field]['type'])) {
-                continue;
-            }
-
-            if ($info['type'] !== $new[$field]['type']) {
-                throw new RuntimeException(sprintf(
-                    "Type mismatch for field '%s' in '%s' DTO during merge.\n"
-                    . "Existing type: '%s', new type: '%s'.\n"
-                    . 'Hint: Field types must be consistent across all configuration files.',
-                    $field,
-                    $dtoName,
-                    $info['type'],
-                    $new[$field]['type'],
-                ));
-            }
-        }
-    }
-
-    /**
      * @param string $configPath
      *
      * @return array<string>
      */
-    protected function _getFiles(string $configPath): array
+    protected function getFiles(string $configPath): array
     {
         $extension = $this->engine->extension();
-
-        $files = $this->_finder()->collect($configPath, $extension);
+        $files = $this->finder()->collect($configPath, $extension);
 
         $this->engine->validate($files);
 
@@ -785,12 +280,14 @@ class Builder
     }
 
     /**
+     * Get namespace from options.
+     *
      * @param string|null $namespace
      * @param string|null $plugin
      *
      * @return string
      */
-    protected function _getNamespace(?string $namespace, ?string $plugin): string
+    protected function getNamespace(?string $namespace, ?string $plugin): string
     {
         if ($namespace) {
             return $namespace;
@@ -803,6 +300,8 @@ class Builder
     }
 
     /**
+     * Build metadata from fields.
+     *
      * @param array<string, mixed> $fields
      *
      * @return array<string, mixed>
@@ -825,9 +324,11 @@ class Builder
     }
 
     /**
+     * Get finder instance.
+     *
      * @return \PhpCollective\Dto\Generator\FinderInterface
      */
-    protected function _finder(): FinderInterface
+    protected function finder(): FinderInterface
     {
         /** @phpstan-var class-string<\PhpCollective\Dto\Generator\Finder> $finderClass */
         $finderClass = $this->config['finder'];
@@ -837,10 +338,6 @@ class Builder
 
     /**
      * Normalize traits configuration to an array of fully qualified class names.
-     *
-     * Supports:
-     * - Single string (comma-separated or single trait)
-     * - Array of trait names
      *
      * @param array<string>|string|null $traits
      *
@@ -853,11 +350,9 @@ class Builder
         }
 
         if (is_string($traits)) {
-            // Support comma-separated traits in XML
             $traits = array_map('trim', explode(',', $traits));
         }
 
-        // Ensure all traits start with backslash
         return array_map(function (string $trait): string {
             $trait = trim($trait);
             if ($trait !== '' && $trait[0] !== '\\') {

--- a/src/Generator/DiffHelperTrait.php
+++ b/src/Generator/DiffHelperTrait.php
@@ -20,7 +20,7 @@ trait DiffHelperTrait
      *
      * @return void
      */
-    protected function _displayDiff(string $oldContent, string $newContent): void
+    protected function displayDiff(string $oldContent, string $newContent): void
     {
         $differ = new Differ(new DiffOnlyOutputBuilder());
         $array = $differ->diffToArray($oldContent, $newContent);

--- a/src/Generator/DtoValidator.php
+++ b/src/Generator/DtoValidator.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Generator;
+
+use InvalidArgumentException;
+use PhpCollective\Dto\Utility\Inflector;
+use RuntimeException;
+
+/**
+ * Validates DTO configuration.
+ */
+class DtoValidator
+{
+    /**
+     * @var \PhpCollective\Dto\Generator\TypeValidator
+     */
+    protected TypeValidator $typeValidator;
+
+    /**
+     * @param \PhpCollective\Dto\Generator\TypeValidator $typeValidator
+     */
+    public function __construct(TypeValidator $typeValidator)
+    {
+        $this->typeValidator = $typeValidator;
+    }
+
+    /**
+     * Validate a DTO definition.
+     *
+     * @param array<string, mixed> $dto
+     *
+     * @return void
+     */
+    public function validate(array $dto): void
+    {
+        $this->validateDtoName($dto);
+        $this->validateFields($dto);
+        $this->validateMethodNameCollisions($dto);
+    }
+
+    /**
+     * Validate DTO name.
+     *
+     * @param array<string, mixed> $dto
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateDtoName(array $dto): void
+    {
+        if (empty($dto['name'])) {
+            throw new InvalidArgumentException(
+                "DTO name missing, but required.\n"
+                . 'Hint: Each DTO definition must have a "name" attribute.',
+            );
+        }
+
+        $dtoName = $dto['name'];
+        if (!$this->typeValidator->isValidDto($dtoName)) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid DTO name `%s`.\n"
+                . 'Hint: DTO names must be PascalCase starting with uppercase letter (e.g., "UserProfile", "OrderItem").',
+                $dtoName,
+            ));
+        }
+    }
+
+    /**
+     * Validate all fields in a DTO.
+     *
+     * @param array<string, mixed> $dto
+     *
+     * @return void
+     */
+    protected function validateFields(array $dto): void
+    {
+        $dtoName = $dto['name'];
+        $fields = $dto['fields'];
+
+        foreach ($fields as $name => $array) {
+            $this->validateFieldName($array, $name, $dtoName);
+            $this->validateFieldType($array, $name, $dtoName);
+            $this->validateFieldAttributes($array, $name, $dtoName);
+            $this->validateFieldCollection($array, $name, $dtoName);
+            $this->validateFieldSingular($array, $name, $dtoName);
+        }
+    }
+
+    /**
+     * Validate field name attribute.
+     *
+     * @param array<string, mixed> $field
+     * @param string $fieldKey
+     * @param string $dtoName
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateFieldName(array $field, string $fieldKey, string $dtoName): void
+    {
+        if (empty($field['name'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Field attribute `name` missing for field `%s` in `%s` DTO.\n"
+                . 'Hint: Each field must have a "name" attribute.',
+                $fieldKey,
+                $dtoName,
+            ));
+        }
+
+        if (!$this->typeValidator->isValidName($field['name'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid field name `%s` in `%s` DTO.\n"
+                . 'Hint: Field names must be alphanumeric starting with a letter (e.g., "userName", "itemCount").',
+                $field['name'],
+                $dtoName,
+            ));
+        }
+    }
+
+    /**
+     * Validate field type attribute.
+     *
+     * @param array<string, mixed> $field
+     * @param string $fieldKey
+     * @param string $dtoName
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateFieldType(array $field, string $fieldKey, string $dtoName): void
+    {
+        if (empty($field['type'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Field attribute `type` missing for field `%s` in `%s` DTO.\n"
+                . 'Hint: Each field must have a "type" attribute (e.g., "string", "int", "ItemDto[]").',
+                $fieldKey,
+                $dtoName,
+            ));
+        }
+
+        if (!$this->typeValidator->isValidType($field['type'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid type `%s` for field `%s` in `%s` DTO.\n"
+                . 'Hint: Valid types include: scalar types (int, string, bool, float), '
+                . 'DTO references (OtherDto), arrays (string[], OtherDto[]), '
+                . 'or fully qualified class names (\\App\\MyClass).',
+                $field['type'],
+                $fieldKey,
+                $dtoName,
+            ));
+        }
+    }
+
+    /**
+     * Validate field attributes are in camelCase format.
+     *
+     * @param array<string, mixed> $field
+     * @param string $fieldKey
+     * @param string $dtoName
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateFieldAttributes(array $field, string $fieldKey, string $dtoName): void
+    {
+        foreach ($field as $key => $value) {
+            $expected = Inflector::variable(Inflector::underscore($key));
+            if ($key !== $expected) {
+                throw new InvalidArgumentException(sprintf(
+                    "Invalid field attribute `%s` for field `%s` in `%s` DTO.\n"
+                    . 'Hint: Expected `%s` (camelCase format).',
+                    $key,
+                    $fieldKey,
+                    $dtoName,
+                    $expected,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Validate field collection configuration.
+     *
+     * @param array<string, mixed> $field
+     * @param string $fieldKey
+     * @param string $dtoName
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateFieldCollection(array $field, string $fieldKey, string $dtoName): void
+    {
+        if (empty($field['collection'])) {
+            return;
+        }
+
+        if (!$this->typeValidator->isValidArray($field['type']) || !$this->typeValidator->isValidCollection($field['type'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid collection type `%s` for field `%s` in `%s` DTO.\n"
+                . 'Hint: Collection types must use array notation (e.g., "string[]", "ItemDto[]").',
+                $field['type'],
+                $fieldKey,
+                $dtoName,
+            ));
+        }
+    }
+
+    /**
+     * Validate field singular configuration.
+     *
+     * @param array<string, mixed> $field
+     * @param string $fieldKey
+     * @param string $dtoName
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateFieldSingular(array $field, string $fieldKey, string $dtoName): void
+    {
+        if (empty($field['singular'])) {
+            return;
+        }
+
+        $expected = Inflector::variable(Inflector::underscore($field['singular']));
+        if ($field['singular'] !== $expected) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid singular name `%s` for field `%s` in `%s` DTO.\n"
+                . 'Hint: Expected `%s` (camelCase format).',
+                $field['singular'],
+                $fieldKey,
+                $dtoName,
+                $expected,
+            ));
+        }
+
+        if (isset($field['collection']) && $field['collection'] === false) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `singular` attribute for non-collection field `%s` in `%s` DTO.\n"
+                . 'Hint: The "singular" attribute is only valid for collection fields.',
+                $fieldKey,
+                $dtoName,
+            ));
+        }
+    }
+
+    /**
+     * Check for method name collisions between fields.
+     *
+     * @param array<string, mixed> $dto
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function validateMethodNameCollisions(array $dto): void
+    {
+        $dtoName = $dto['name'];
+        $fields = $dto['fields'];
+        $methodNames = [];
+
+        foreach ($fields as $array) {
+            $fieldName = $array['name'];
+            $methodName = Inflector::camelize($fieldName);
+
+            if (isset($methodNames[$methodName])) {
+                throw new InvalidArgumentException(sprintf(
+                    "Field name collision in `%s` DTO: fields `%s` and `%s` would generate identical method names.\n"
+                    . 'Hint: Both fields would generate methods like `get%s()`, `set%s()`, etc. Use only one of these field names.',
+                    $dtoName,
+                    $methodNames[$methodName],
+                    $fieldName,
+                    $methodName,
+                    $methodName,
+                ));
+            }
+            $methodNames[$methodName] = $fieldName;
+        }
+    }
+
+    /**
+     * Validate merge compatibility between two DTO definitions.
+     *
+     * @param array<string, mixed>|null $existing
+     * @param array<string, mixed>|null $new
+     *
+     * @throws \RuntimeException
+     *
+     * @return void
+     */
+    public function validateMerge(?array $existing, ?array $new): void
+    {
+        if (!$existing || !$new) {
+            return;
+        }
+
+        $dtoName = $existing['name'] ?? 'unknown';
+
+        foreach ($existing as $field => $info) {
+            if (!isset($new[$field])) {
+                continue;
+            }
+            if (!isset($info['type'])) {
+                continue;
+            }
+            if (!isset($new[$field]['type'])) {
+                continue;
+            }
+
+            if ($info['type'] !== $new[$field]['type']) {
+                throw new RuntimeException(sprintf(
+                    "Type mismatch for field `%s` in `%s` DTO during merge.\n"
+                    . "Existing type: `%s`, new type: `%s`.\n"
+                    . 'Hint: Field types must be consistent across all configuration files.',
+                    $field,
+                    $dtoName,
+                    $info['type'],
+                    $new[$field]['type'],
+                ));
+            }
+        }
+    }
+}

--- a/src/Generator/ExtendsResolver.php
+++ b/src/Generator/ExtendsResolver.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Generator;
+
+use InvalidArgumentException;
+use PhpCollective\Dto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
+use ReflectionClass;
+
+/**
+ * Resolves and validates DTO inheritance (extends attribute).
+ */
+class ExtendsResolver
+{
+    /**
+     * @var string
+     */
+    protected string $suffix;
+
+    /**
+     * @param string $suffix
+     */
+    public function __construct(string $suffix)
+    {
+        $this->suffix = $suffix;
+    }
+
+    /**
+     * Resolve extends references for all DTOs.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function resolve(array $config): array
+    {
+        foreach ($config as $name => $dto) {
+            $config[$name] = $this->resolveExtends($dto, $config);
+        }
+
+        return $config;
+    }
+
+    /**
+     * Resolve extends for a single DTO.
+     *
+     * @param array<string, mixed> $dto
+     * @param array<string, mixed> $allDtos
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveExtends(array $dto, array $allDtos): array
+    {
+        $extends = $dto['extends'];
+
+        if (in_array($extends, ['\\PhpCollective\\Dto\\Dto\\AbstractDto', '\\PhpCollective\\Dto\\Dto\\AbstractImmutableDto'], true)) {
+            return $dto;
+        }
+
+        $isImmutable = !empty($dto['immutable']);
+
+        if (isset($allDtos[$extends])) {
+            $dto = $this->resolveInternalExtends($dto, $extends, $allDtos, $isImmutable);
+        } else {
+            $dto = $this->resolveExternalExtends($dto, $extends, $isImmutable);
+        }
+
+        return $dto;
+    }
+
+    /**
+     * Resolve extends to another DTO in the same config.
+     *
+     * @param array<string, mixed> $dto
+     * @param string $extends
+     * @param array<string, mixed> $allDtos
+     * @param bool $isImmutable
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveInternalExtends(array $dto, string $extends, array $allDtos, bool $isImmutable): array
+    {
+        $dto['extends'] = $extends . $this->suffix;
+
+        if (!$isImmutable && !empty($allDtos[$extends]['immutable'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `extends` attribute for `%s` DTO: cannot extend immutable DTO `%s`.\n"
+                . 'Hint: Either make `%s` immutable, or extend a mutable DTO instead.',
+                $dto['name'],
+                $extends,
+                $dto['name'],
+            ));
+        }
+
+        if ($isImmutable && empty($allDtos[$extends]['immutable'])) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `extends` attribute for `%s` DTO: immutable DTO cannot extend mutable DTO `%s`.\n"
+                . 'Hint: Either make `%s` mutable, or make `%s` immutable.',
+                $dto['name'],
+                $extends,
+                $dto['name'],
+                $extends,
+            ));
+        }
+
+        return $dto;
+    }
+
+    /**
+     * Resolve extends to an external class.
+     *
+     * @param array<string, mixed> $dto
+     * @param string $extends
+     * @param bool $isImmutable
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveExternalExtends(array $dto, string $extends, bool $isImmutable): array
+    {
+        if (!class_exists($extends)) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `extends` attribute for `%s` DTO: class `%s` does not exist.\n"
+                . 'Hint: Check the class name spelling and ensure the class is autoloadable.',
+                $dto['name'],
+                $extends,
+            ));
+        }
+
+        $extendedDtoReflectionClass = new ReflectionClass($extends);
+
+        if ($extendedDtoReflectionClass->getParentClass() === false) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `extends` attribute for `%s` DTO: `%s` must extend %s.\n"
+                . 'Hint: The parent class should be a DTO class extending the appropriate base.',
+                $dto['name'],
+                $extends,
+                $isImmutable ? AbstractImmutableDto::class : AbstractDto::class,
+            ));
+        }
+
+        if ($isImmutable && !$extendedDtoReflectionClass->isSubclassOf(AbstractImmutableDto::class)) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `extends` attribute for `%s` DTO: `%s` is not immutable.\n"
+                . 'Hint: Immutable DTOs must extend other immutable DTOs or AbstractImmutableDto.',
+                $dto['name'],
+                $extends,
+            ));
+        }
+
+        if (!$isImmutable && !$extendedDtoReflectionClass->isSubclassOf(AbstractDto::class)) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid `extends` attribute for `%s` DTO: `%s` is immutable.\n"
+                . 'Hint: Mutable DTOs cannot extend immutable DTOs. Either make `%s` immutable or change the parent.',
+                $dto['name'],
+                $extends,
+                $dto['name'],
+            ));
+        }
+
+        return $dto;
+    }
+
+    /**
+     * Resolve namespace paths in extends references.
+     *
+     * @param array<string, mixed> $config
+     * @param string $namespace
+     *
+     * @return array<string, mixed>
+     */
+    public function resolveNamespacePaths(array $config, string $namespace): array
+    {
+        foreach ($config as $name => $dto) {
+            if (strpos($dto['className'], '/') !== false) {
+                $pieces = explode('/', $dto['className']);
+                $dto['className'] = array_pop($pieces);
+                $dto['namespace'] .= '\\' . implode('\\', $pieces);
+            }
+
+            if (!empty($dto['extends']) && strpos($dto['extends'], '/') !== false) {
+                $pieces = explode('/', $dto['extends']);
+                $dto['extends'] = '\\' . $namespace . '\Dto\\' . implode('\\', $pieces);
+            }
+
+            $config[$name] = $dto;
+        }
+
+        return $config;
+    }
+}

--- a/src/Generator/FieldCompletor.php
+++ b/src/Generator/FieldCompletor.php
@@ -1,0 +1,476 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Dto\Generator;
+
+use InvalidArgumentException;
+use PhpCollective\Dto\Utility\Inflector;
+
+/**
+ * Completes and enriches field definitions with computed values.
+ */
+class FieldCompletor
+{
+    /**
+     * @var \PhpCollective\Dto\Generator\TypeValidator
+     */
+    protected TypeValidator $typeValidator;
+
+    /**
+     * @var \PhpCollective\Dto\Generator\TypeResolver
+     */
+    protected TypeResolver $typeResolver;
+
+    /**
+     * @var \PhpCollective\Dto\Generator\ArrayShapeBuilder
+     */
+    protected ArrayShapeBuilder $arrayShapeBuilder;
+
+    /**
+     * @var string
+     */
+    protected string $defaultCollectionType;
+
+    /**
+     * @var string
+     */
+    protected string $suffix;
+
+    /**
+     * @var bool
+     */
+    protected bool $scalarAndReturnTypes;
+
+    /**
+     * @param \PhpCollective\Dto\Generator\TypeValidator $typeValidator
+     * @param \PhpCollective\Dto\Generator\TypeResolver $typeResolver
+     * @param \PhpCollective\Dto\Generator\ArrayShapeBuilder $arrayShapeBuilder
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        TypeValidator $typeValidator,
+        TypeResolver $typeResolver,
+        ArrayShapeBuilder $arrayShapeBuilder,
+        array $config,
+    ) {
+        $this->typeValidator = $typeValidator;
+        $this->typeResolver = $typeResolver;
+        $this->arrayShapeBuilder = $arrayShapeBuilder;
+        $this->defaultCollectionType = $config['defaultCollectionType'] ?? '\ArrayObject';
+        $this->suffix = $config['suffix'] ?? 'Dto';
+        $this->scalarAndReturnTypes = $config['scalarAndReturnTypes'] ?? true;
+    }
+
+    /**
+     * Complete field definitions with defaults and computed values.
+     *
+     * @param array<string, mixed> $dto
+     * @param string $namespace
+     *
+     * @return array<string, mixed>
+     */
+    public function complete(array $dto, string $namespace): array
+    {
+        $dtoName = $dto['name'];
+        $fields = $dto['fields'];
+
+        $fields = $this->addFieldDefaults($fields);
+        $fields = $this->resolveFieldTypes($fields, $dtoName, $namespace);
+
+        $dto['fields'] = $fields;
+
+        return $dto;
+    }
+
+    /**
+     * Complete field metadata (type hints, return types, etc.).
+     *
+     * @param array<string, mixed> $dto
+     * @param string $namespace
+     *
+     * @return array<string, mixed>
+     */
+    public function completeMeta(array $dto, string $namespace): array
+    {
+        $fields = $dto['fields'];
+
+        foreach ($fields as $key => $field) {
+            $fields[$key] = $this->completeFieldTypeHints($field, $namespace);
+            $fields[$key] = $this->completeCollectionTypeHints($fields[$key]);
+            $fields[$key] = $this->completeArrayTypeHints($fields[$key]);
+            $fields[$key] = $this->completeNullableTypeHints($fields[$key]);
+            $fields[$key] = $this->completeSingularTypeHints($fields[$key]);
+        }
+
+        $dto['fields'] = $fields;
+        $dto += [
+            'deprecated' => null,
+        ];
+
+        return $dto;
+    }
+
+    /**
+     * Add default values to all fields.
+     *
+     * @param array<string, mixed> $fields
+     *
+     * @return array<string, mixed>
+     */
+    protected function addFieldDefaults(array $fields): array
+    {
+        foreach ($fields as $field => $data) {
+            $data += [
+                'required' => false,
+                'defaultValue' => null,
+                'nullable' => empty($data['required']),
+                'returnTypeHint' => null,
+                'nullableTypeHint' => null,
+                'isArray' => false,
+                'dto' => null,
+                'collection' => !empty($data['singular']),
+                'collectionType' => null,
+                'associative' => false,
+                'key' => null,
+                'deprecated' => null,
+                'serialize' => null,
+                'factory' => null,
+                'mapFrom' => null,
+                'mapTo' => null,
+                'transformFrom' => null,
+                'transformTo' => null,
+            ];
+
+            if ($data['required']) {
+                $data['nullable'] = false;
+            }
+
+            $fields[$field] = $data;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Resolve and validate field types.
+     *
+     * @param array<string, mixed> $fields
+     * @param string $dtoName
+     * @param string $namespace
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveFieldTypes(array $fields, string $dtoName, string $namespace): array
+    {
+        foreach ($fields as $key => $field) {
+            if ($this->typeValidator->isValidSimpleType($field['type'], $this->typeValidator->getSimpleTypeAdditionsForDocBlock())) {
+                continue;
+            }
+
+            if ($this->typeValidator->isValidDto($field['type'])) {
+                $fields[$key]['dto'] = $field['type'];
+
+                continue;
+            }
+
+            if ($this->isCollection($field)) {
+                $fields[$key] = $this->resolveCollectionField($fields[$key], $dtoName, $namespace, $fields);
+
+                continue;
+            }
+
+            if ($this->typeValidator->isValidArray($field['type'])) {
+                $fields[$key]['isArray'] = true;
+                if (preg_match('#^([A-Z][a-zA-Z/]+)\[\]$#', $field['type'], $matches)) {
+                    $fields[$key]['type'] = $this->typeResolver->dtoTypeToClass($matches[1], $namespace, $this->suffix) . '[]';
+                }
+
+                continue;
+            }
+
+            if ($this->typeValidator->isValidInterfaceOrClass($field['type'])) {
+                $fields[$key]['isClass'] = true;
+
+                if (empty($fields[$key]['serialize'])) {
+                    $fields[$key]['serialize'] = $this->typeResolver->detectSerialize($fields[$key]);
+                }
+
+                $fields[$key]['enum'] = $this->typeResolver->enumType($field['type']);
+
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf(
+                "Invalid type `%s` for field `%s` in `%s` DTO.\n"
+                . 'Hint: Valid types include: scalar types (int, string, bool, float), '
+                . 'DTO references (OtherDto), arrays (string[], OtherDto[]), '
+                . 'or fully qualified class names (\\App\\MyClass).',
+                $field['type'],
+                $key,
+                $dtoName,
+            ));
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Check if a field is a collection.
+     *
+     * @param array<string, mixed> $field
+     *
+     * @return bool
+     */
+    public function isCollection(array $field): bool
+    {
+        return $field['collection'] || $field['collectionType'] || $field['associative'];
+    }
+
+    /**
+     * Resolve collection field configuration.
+     *
+     * @param array<string, mixed> $field
+     * @param string $dtoName
+     * @param string $namespace
+     * @param array<string, mixed> $allFields
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveCollectionField(array $field, string $dtoName, string $namespace, array $allFields): array
+    {
+        $field['collection'] = true;
+        $field['collectionType'] = $this->typeResolver->collectionType($field, $this->defaultCollectionType);
+        $field['nullable'] = false;
+
+        $field = $this->completeCollectionSingular($field, $dtoName, $namespace, $allFields);
+        $field['singularNullable'] = substr($field['type'], 0, 1) === '?';
+
+        if (!empty($field['singular'])) {
+            $singular = $field['singular'];
+            if (!empty($allFields[$singular])) {
+                throw new InvalidArgumentException(sprintf(
+                    "Invalid singular name `%s` for collection field `%s` in `%s` DTO.\n"
+                    . 'Hint: The singular name conflicts with existing field `%s`. Use a different singular name.',
+                    $singular,
+                    $field['name'],
+                    $dtoName,
+                    $singular,
+                ));
+            }
+        }
+
+        if (preg_match('#^([A-Z][a-zA-Z/]+)\[\]$#', $field['type'], $matches)) {
+            $field['type'] = $this->typeResolver->dtoTypeToClass($matches[1], $namespace, $this->suffix) . '[]';
+        }
+
+        if ($field['singularNullable']) {
+            $field['type'] = '(' . $field['singularType'] . '|null)[]';
+        }
+
+        return $field;
+    }
+
+    /**
+     * Complete collection singular configuration.
+     *
+     * @param array<string, mixed> $data
+     * @param string $dtoName
+     * @param string $namespace
+     * @param array<string, mixed> $fields
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array<string, mixed>
+     */
+    protected function completeCollectionSingular(array $data, string $dtoName, string $namespace, array $fields): array
+    {
+        $fieldName = $data['name'];
+        if (!$data['collection'] && empty($data['collectionType'])) {
+            return $data;
+        }
+
+        $data['singularType'] = $this->typeResolver->singularType($data['type']);
+        if ($data['singularType'] && $this->typeValidator->isValidDto($data['singularType'])) {
+            $data['singularType'] = $this->typeResolver->dtoTypeToClass($data['singularType'], $namespace, $this->suffix);
+            $data['singularClass'] = $data['singularType'];
+        }
+
+        if (!empty($data['singular'])) {
+            return $data;
+        }
+
+        $singular = Inflector::singularize($fieldName);
+        if ($singular === $fieldName) {
+            throw new InvalidArgumentException(sprintf(
+                "Cannot auto-singularize field name `%s` in `%s` DTO.\n"
+                . 'Hint: The field name `%s` has no singular form. Add an explicit `singular` attribute (e.g., singular="%sItem").',
+                $fieldName,
+                $dtoName,
+                $fieldName,
+                $fieldName,
+            ));
+        }
+
+        // Collision detection
+        if (!empty($fields[$singular])) {
+            throw new InvalidArgumentException(sprintf(
+                "Auto-generated singular `%s` for collection field `%s` in `%s` DTO collides with existing field.\n"
+                . 'Hint: Add an explicit `singular` attribute with a unique name to avoid this collision.',
+                $singular,
+                $fieldName,
+                $dtoName,
+            ));
+        }
+
+        $data['singular'] = $singular;
+
+        return $data;
+    }
+
+    /**
+     * Complete field type hints.
+     *
+     * @param array<string, mixed> $field
+     * @param string $namespace
+     *
+     * @return array<string, mixed>
+     */
+    protected function completeFieldTypeHints(array $field, string $namespace): array
+    {
+        if ($field['dto']) {
+            $className = $this->typeResolver->dtoTypeToClass($field['type'], $namespace, $this->suffix);
+            $field['type'] = $className;
+            $field['typeHint'] = $className;
+        } else {
+            $field['typeHint'] = $field['type'];
+        }
+
+        $field['typeHint'] = $this->typeResolver->typehint($field['typeHint']);
+
+        return $field;
+    }
+
+    /**
+     * Complete collection type hints.
+     *
+     * @param array<string, mixed> $field
+     *
+     * @return array<string, mixed>
+     */
+    protected function completeCollectionTypeHints(array $field): array
+    {
+        if (!$field['collection']) {
+            return $field;
+        }
+
+        if ($field['collectionType'] === 'array') {
+            $field['typeHint'] = 'array';
+            $field['docBlockType'] = $this->arrayShapeBuilder->buildGenericArrayType($field);
+        } else {
+            $field['typeHint'] = $field['collectionType'];
+            $field['type'] .= '|' . $field['typeHint'];
+            $field['docBlockType'] = $this->arrayShapeBuilder->buildGenericCollectionType($field);
+        }
+
+        return $field;
+    }
+
+    /**
+     * Complete array type hints.
+     *
+     * @param array<string, mixed> $field
+     *
+     * @return array<string, mixed>
+     */
+    protected function completeArrayTypeHints(array $field): array
+    {
+        if (!$field['isArray']) {
+            return $field;
+        }
+
+        if ($field['type'] !== 'array') {
+            $field['typeHint'] = 'array';
+            $field['docBlockType'] = $this->arrayShapeBuilder->buildGenericArrayType($field);
+        }
+
+        return $field;
+    }
+
+    /**
+     * Complete nullable type hints.
+     *
+     * @param array<string, mixed> $field
+     *
+     * @return array<string, mixed>
+     */
+    protected function completeNullableTypeHints(array $field): array
+    {
+        if ($field['typeHint'] && $this->scalarAndReturnTypes) {
+            $field['returnTypeHint'] = $field['typeHint'];
+
+            if ($field['nullable']) {
+                if ($this->typeResolver->isUnionType($field['typeHint'])) {
+                    $field['nullableReturnTypeHint'] = $field['typeHint'] . '|null';
+                } else {
+                    $field['nullableReturnTypeHint'] = '?' . $field['typeHint'];
+                }
+            }
+        }
+
+        if ($field['typeHint'] && $this->scalarAndReturnTypes && $field['nullable']) {
+            if ($this->typeResolver->isUnionType($field['typeHint'])) {
+                $field['nullableTypeHint'] = $field['typeHint'] . '|null';
+            } else {
+                $field['nullableTypeHint'] = '?' . $field['typeHint'];
+            }
+        }
+
+        return $field;
+    }
+
+    /**
+     * Complete singular type hints for collections.
+     *
+     * @param array<string, mixed> $field
+     *
+     * @return array<string, mixed>
+     */
+    protected function completeSingularTypeHints(array $field): array
+    {
+        if (!$field['collection']) {
+            return $field;
+        }
+
+        $field += [
+            'singularTypeHint' => null,
+            'singularNullable' => false,
+            'singularReturnTypeHint' => null,
+            'singularNullableReturnTypeHint' => null,
+        ];
+
+        if ($field['singularType']) {
+            $field['singularTypeHint'] = $this->typeResolver->typehint($field['singularType']);
+        }
+
+        if ($field['singularTypeHint'] && $this->scalarAndReturnTypes) {
+            $field['singularReturnTypeHint'] = $field['singularTypeHint'];
+
+            if ($field['singularNullable']) {
+                if ($this->typeResolver->isUnionType($field['singularTypeHint'])) {
+                    $field['singularNullableReturnTypeHint'] = $field['singularTypeHint'] . '|null';
+                } else {
+                    $field['singularNullableReturnTypeHint'] = '?' . $field['singularTypeHint'];
+                }
+            }
+        }
+
+        $field['keyType'] = !empty($field['associative']) ? 'string' : 'int';
+
+        return $field;
+    }
+}

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -114,7 +114,7 @@ class Generator
             if ($isModified) {
                 $this->io->out('Changes in ' . $name . ' DTO:', 1, IoInterface::VERBOSE);
                 $oldContent = file_get_contents($foundDtos[$name]) ?: '';
-                $this->_displayDiff($oldContent, $content);
+                $this->displayDiff($oldContent, $content);
             }
             if (!$options['dryRun']) {
                 file_put_contents($target, $content);
@@ -188,7 +188,7 @@ class Generator
             if ($isModified) {
                 $this->io->out('Changes in ' . $name . ' Mapper:', 1, IoInterface::VERBOSE);
                 $oldContent = file_get_contents($foundMappers[$name]) ?: '';
-                $this->_displayDiff($oldContent, $content);
+                $this->displayDiff($oldContent, $content);
             }
             if (!$options['dryRun']) {
                 file_put_contents($target, $content);

--- a/tests/Generator/BuilderEdgeCaseTest.php
+++ b/tests/Generator/BuilderEdgeCaseTest.php
@@ -1483,8 +1483,8 @@ PHP;
         $builder = new Builder($engine, $config);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Field name collision in 'User' DTO");
-        $this->expectExceptionMessage("fields '_data' and 'data' would generate identical method names");
+        $this->expectExceptionMessage('Field name collision in `User` DTO');
+        $this->expectExceptionMessage('fields `_data` and `data` would generate identical method names');
 
         $builder->build($this->tempDir . '/config/');
     }


### PR DESCRIPTION
## Summary

Split the 870-line `Builder` class into 4 focused classes following Single Responsibility Principle.

## Changes

| Class | Lines | Responsibility |
|-------|-------|----------------|
| `Builder` | 365 | Orchestration, configuration, file handling |
| `DtoValidator` | 330 | DTO and field validation |
| `FieldCompletor` | 476 | Field completion and type resolution |
| `ExtendsResolver` | 196 | Inheritance resolution and validation |

## Benefits

- Each class has a single, clear responsibility
- Easier to understand and navigate
- Easier to test individual components
- Easier to extend or modify specific behaviors
- Consistent error message formatting with backticks