### PR TITLE
Remove deprecated Serializable interface

### DIFF
--- a/src/Dto/AbstractDto.php
+++ b/src/Dto/AbstractDto.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpCollective\Dto\Dto;
 
-use PhpCollective\Dto\Utility\Json;
 use RuntimeException;
 
 abstract class AbstractDto extends Dto
@@ -19,26 +18,6 @@ abstract class AbstractDto extends Dto
     public function fromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static
     {
         return $this->setFromArray($data, $ignoreMissing, $type);
-    }
-
-    /**
-     * Constructs the object
-     *
-     * @link https://php.net/manual/en/serializable.unserialize.php
-     *
-     * @deprecated Use __unserialize() instead. The Serializable interface is deprecated in PHP 8.1+.
-     *
-     * @param string $serialized
-     * @param bool $ignoreMissing
-     *
-     * @return $this
-     */
-    public function unserialize($serialized, $ignoreMissing = false)
-    {
-        $jsonUtil = new Json();
-        $this->fromArray($jsonUtil->decode($serialized, true) ?: [], $ignoreMissing);
-
-        return $this;
     }
 
     /**

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -11,12 +11,11 @@ use InvalidArgumentException;
 use JsonSerializable;
 use PhpCollective\Dto\Utility\Json;
 use RuntimeException;
-use Serializable;
 use Throwable;
 use Traversable;
 use UnitEnum;
 
-abstract class Dto implements Serializable, JsonSerializable
+abstract class Dto implements JsonSerializable
 {
     /**
      * Convert DTO to array. Implemented by generated DTOs with shaped array return types.
@@ -129,28 +128,6 @@ abstract class Dto implements Serializable, JsonSerializable
         $jsonUtil = new Json();
 
         return new static($jsonUtil->decode($data, true), $ignoreMissing);
-    }
-
-    /**
-     * Constructs the object
-     *
-     * @link https://php.net/manual/en/serializable.unserialize.php
-     *
-     * @deprecated Use __unserialize() instead. The Serializable interface is deprecated in PHP 8.1+.
-     *
-     * @param string $data
-     * @param bool $ignoreMissing
-     *
-     * @return static
-     */
-    public function unserialize(string $data, bool $ignoreMissing = false)
-    {
-        $jsonUtil = new Json();
-
-        $new = clone($this);
-        $new->setFromArray($jsonUtil->decode($data, true) ?: [], $ignoreMissing, static::TYPE_DEFAULT)->setDefaults()->validate();
-
-        return $new;
     }
 
     /**
@@ -891,7 +868,9 @@ abstract class Dto implements Serializable, JsonSerializable
      */
     public function __toString(): string
     {
-        return $this->serialize();
+        $jsonUtil = new Json();
+
+        return $jsonUtil->encode($this->touchedToArray());
     }
 
     /**
@@ -908,22 +887,6 @@ abstract class Dto implements Serializable, JsonSerializable
             'extends' => get_parent_class($this),
             'immutable' => $this instanceof AbstractImmutableDto,
         ];
-    }
-
-    /**
-     * String representation of object
-     *
-     * @link https://php.net/manual/en/serializable.serialize.php
-     *
-     * @deprecated Use __serialize() instead. The Serializable interface is deprecated in PHP 8.1+.
-     *
-     * @return string the string representation of the object or null
-     */
-    public function serialize(): string
-    {
-        $jsonUtil = new Json();
-
-        return $jsonUtil->encode($this->touchedToArray());
     }
 
     /**

--- a/tests/Dto/DtoTest.php
+++ b/tests/Dto/DtoTest.php
@@ -152,10 +152,10 @@ class DtoTest extends TestCase
         $this->assertFalse(isset($dto->count));
     }
 
-    public function testSerialize(): void
+    public function testJsonStringOutput(): void
     {
         $dto = new SimpleDto(['name' => 'Test', 'count' => 5]);
-        $serialized = $dto->serialize();
+        $serialized = (string)$dto;
         $this->assertJson($serialized);
         $decoded = json_decode($serialized, true);
         $this->assertSame('Test', $decoded['name']);
@@ -578,7 +578,7 @@ class DtoTest extends TestCase
     public function testFromUnserialized(): void
     {
         $dto = new SimpleDto(['name' => 'Test', 'count' => 5]);
-        $serialized = $dto->serialize();
+        $serialized = (string)$dto;
 
         $unserialized = SimpleDto::fromUnserialized($serialized);
 
@@ -855,18 +855,6 @@ class DtoTest extends TestCase
         $this->assertSame('original', $clone->getFactoryData()->value);
     }
 
-    public function testUnserializeMethodOnAbstractDto(): void
-    {
-        $dto = new SimpleDto(['name' => 'Original', 'count' => 1]);
-        $serialized = $dto->serialize();
-
-        $newDto = new SimpleDto();
-        $result = $newDto->unserialize($serialized);
-
-        $this->assertSame('Original', $result->getName());
-        $this->assertSame(1, $result->getCount());
-    }
-
     public function testFromArrayWithUnderscoredType(): void
     {
         $dto = new CollectionDto();
@@ -940,34 +928,6 @@ class DtoTest extends TestCase
         // Factory NOT called because CollectionDto uses ArrayObject collectionType
         $this->assertFalse($factoryCalled);
         $this->assertInstanceOf(ArrayObject::class, $dto->getItems());
-    }
-
-    public function testAbstractDtoUnserializeModifiesSelf(): void
-    {
-        // AbstractDto::unserialize() modifies $this and returns $this
-        // (unlike Dto::unserialize() which returns a clone)
-        $dto = new SimpleDto(['name' => 'Original']);
-        $json = '{"name":"FromJson","count":42}';
-
-        $result = $dto->unserialize($json);
-
-        // Result is the same instance (AbstractDto behavior)
-        $this->assertSame($dto, $result);
-
-        // DTO was modified in place
-        $this->assertSame('FromJson', $dto->getName());
-        $this->assertSame(42, $dto->getCount());
-    }
-
-    public function testAbstractDtoUnserializeWithIgnoreMissing(): void
-    {
-        $dto = new SimpleDto();
-        $json = '{"name":"Test","unknownField":"ignored"}';
-
-        // Should not throw with ignoreMissing
-        $result = $dto->unserialize($json, true);
-
-        $this->assertSame('Test', $result->getName());
     }
 
     public function testCloneWithScalarCollectionValues(): void


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Remove the deprecated `Serializable` interface and associated methods from DTO classes.

The `Serializable` interface has been deprecated in PHP 8.1+ in favor of the `__serialize()`/`__unserialize()` magic methods. This PR removes the deprecated interface and methods to prepare for a major version bump.

### Removed

| Class | Method/Interface | Status |
|-------|------------------|--------|
| `Dto` | `implements Serializable` | Removed |
| `Dto` | `serialize(): string` | Removed |
| `Dto` | `unserialize(string $data, bool $ignoreMissing = false): static` | Removed |
| `AbstractDto` | `unserialize($serialized, $ignoreMissing = false)` | Removed |

### Still Available

The following remain available for JSON and native PHP serialization:

| Method | Purpose |
|--------|---------|
| `__toString()` | Returns JSON representation (same as old `serialize()`) |
| `__serialize()` | Used by PHP's native `serialize()` function |
| `__unserialize()` | Used by PHP's native `unserialize()` function |
| `Dto::fromUnserialized()` | Static factory to create DTO from JSON string |
| `jsonSerialize()` | For `json_encode()` support |

## Migration Guide

### Before (deprecated)

```php
// Serializing to JSON
$json = $dto->serialize();

// Unserializing from JSON (Dto)
$newDto = $dto->unserialize($json);

// Unserializing from JSON (AbstractDto)
$dto->unserialize($json);
```

### After

```php
// Serializing to JSON - use __toString() or json_encode()
$json = (string)$dto;
// or
$json = json_encode($dto);

// Unserializing from JSON - use static factory
$newDto = MyDto::fromUnserialized($json);

// For AbstractDto - use fromArray() with decoded JSON
$dto->fromArray(json_decode($json, true));
```

### Native PHP Serialization

Native PHP serialization continues to work via magic methods:

```php
// These still work (using __serialize/__unserialize internally)
$serialized = serialize($dto);
$dto = unserialize($serialized);
```

## Why This Change?

1. **PHP 8.1+ Deprecation**: The `Serializable` interface is deprecated and will be removed in a future PHP version
2. **Cleaner API**: The `serialize()` method name was confusing as it returned JSON, not PHP serialization format
3. **Reduced Complexity**: Fewer methods to maintain with the same functionality available via alternatives

## Checklist

- [x] Tests pass
- [x] PHPStan passes
- [x] PHPCS passes
- [x] Updated tests to use new methods
- [x] Documented migration path

---

**Note**: This is a breaking change intended for the next major version (e.g., 1.0.0 or 2.0.0).