### PR TITLE
Fix optimizations template to use collection adapter for append

### DIFF
--- a/templates/element/optimizations.twig
+++ b/templates/element/optimizations.twig
@@ -36,8 +36,9 @@
 			$this->_touchedFields['{{ field.name }}'] = true;
 		}
 {% elseif field.collection and field.collectionType != 'array' %}
+{% set adapter = getCollectionAdapter(field.collectionType) %}
 		if (isset($data['{{ field.name }}'])) {
-			$collection = new {{ field.collectionType }}();
+			$collection = {{ adapter.getCreateEmptyCode(field.collectionType) }};
 			/** @var array $items */
 			$items = $data['{{ field.name }}'];
 			foreach ($items as $key => $item) {
@@ -54,8 +55,10 @@
 					$key = $data['{{ field.name }}'][$key]['{{ field.key }}'];
 				}
 				$collection[$key] = $item;
+{% elseif field.associative %}
+				$collection[$key] = $item;
 {% else %}
-				$collection->append($item);
+				{{ adapter.getAppendCode('$collection', '$item') }}
 {% endif %}
 			}
 			$this->{{ field.name }} = $collection;


### PR DESCRIPTION
## Summary
- Use adapter.getCreateEmptyCode() instead of hardcoded constructor
- Use adapter.getAppendCode() instead of hardcoded append()
- Fixes compatibility with Laravel Collection (uses push()) and Doctrine ArrayCollection (uses add())
- Also handles associative collections without specific key field

This fix is needed because the template was hardcoding `$collection->append($item)` which only works for ArrayObject. Laravel's Collection uses `push()` and Doctrine's ArrayCollection uses `add()`.
