### PR TITLE
Fix README immutable API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A more realistic example using immutable DTOs for a blog system:
 ```php
 // config/dto.php
 return Schema::create()
-    ->dto(Dto::create('Article')->immutable()->fields(
+    ->dto(Dto::immutable('Article')->fields(
         Field::int('id')->required(),
         Field::string('title')->required(),
         Field::string('slug')->required(),
@@ -77,12 +77,12 @@ return Schema::create()
         Field::bool('published')->defaultValue(false),
         Field::string('publishedAt'),
     ))
-    ->dto(Dto::create('Author')->immutable()->fields(
+    ->dto(Dto::immutable('Author')->fields(
         Field::string('name')->required(),
         Field::string('email'),
         Field::string('avatarUrl'),
     ))
-    ->dto(Dto::create('Tag')->immutable()->fields(
+    ->dto(Dto::immutable('Tag')->fields(
         Field::string('name')->required(),
         Field::string('slug')->required(),
     ))


### PR DESCRIPTION
The README examples used `Dto::create('Article')->immutable()` which incorrectly calls the static factory method `immutable(string $name)` as a no-argument instance method.

The correct APIs are:
- `Dto::immutable('Article')` — static factory (used in all other docs)
- `Dto::create('Article')->asImmutable()` — instance method

This fixes the 3 occurrences in the Immutable DTOs section to use `Dto::immutable('Name')`, consistent with ConfigBuilder.md and all other documentation.
