### PR TITLE
Improve documentation for validation, lazy, and readonly features

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Reading in a template (e.g., Twig, Blade, or plain PHP):
 ## Features
 
 - **Types**: `int`, `float`, `string`, `bool`, `array`, `mixed`, DTOs, classes, enums
-- **Union types**: `int|string`, `int|float|string` (PHP 8.0+)
+- **Union types**: `int|string`, `int|float|string`
 - **Collections**: `'type' => 'Item[]', 'collection' => true` with add/remove/get/has methods
 - **Associative collections**: keyed access with `'associative' => true`
 - **Immutable DTOs**: `'immutable' => true` with `with*()` methods

--- a/docs/ConfigBuilder.md
+++ b/docs/ConfigBuilder.md
@@ -555,7 +555,7 @@ Dto::create('Config')->readonlyProperties()->fields(
 This generates `public readonly` properties instead of `protected` ones, providing:
 
 - Direct public property access (`$dto->host` instead of `$dto->getHost()`)
-- Compile-time immutability enforcement (assignment after construction throws `\Error`)
+- Immutability enforcement (assignment after construction throws `\Error`)
 - Getters are still generated for consistency
 
 Note: `readonlyProperties()` implies `immutable` — the DTO will extend `AbstractImmutableDto`

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -704,12 +704,12 @@ echo $customer->getName();  // "John"
 
 ### Pass-Through Optimization
 
-When data is validated and forwarded without deep inspection:
+When data is forwarded without deep inspection, lazy fields avoid unnecessary object creation:
 
 ```php
 // API gateway scenario
 $orderData = $this->fetchFromUpstreamApi();
-$order = new OrderDto($orderData);  // Validates structure
+$order = new OrderDto($orderData);
 
 // Forward to downstream service - no nested objects created
 $this->downstreamApi->send($order->toArray());
@@ -792,7 +792,6 @@ Dto::immutable('Event')->fields(
 
 $event = new EventDto(['name' => 'user.created', 'payload' => '{}']);
 echo $event->getName();     // Access via getter
-// $event->name;            // Error - property is protected
 
 // Readonly DTO - direct property access
 Dto::create('Event')->readonlyProperties()->fields(


### PR DESCRIPTION
## Summary

- Add validation rules, lazy properties, readonly properties to README features list
- Expand lazy loading docs with usage examples, toArray behavior, and when-to-use guidance
- Add readonly vs immutable comparison table with recommendations
- Add Examples.md sections for validation rules, lazy loading, and readonly properties