### PR TITLE
Add VitePress documentation site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,61 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs
+
+      - name: Build docs
+        run: npm run docs:build
+        working-directory: docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vitepress/cache/
+.vitepress/dist/

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,121 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: 'PHP DTO',
+  description: 'Framework-agnostic DTO library with code generation for PHP',
+
+  base: '/dto/',
+
+  head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/dto/logo.svg' }],
+    ['meta', { name: 'theme-color', content: '#7c3aed' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'PHP DTO - Code Generation for Data Transfer Objects' }],
+    ['meta', { property: 'og:description', content: 'Framework-agnostic DTO library with code generation. Zero runtime overhead, perfect IDE support, and TypeScript generation.' }],
+  ],
+
+  themeConfig: {
+    logo: '/logo.svg',
+
+    nav: [
+      { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
+      { text: 'Reference', link: '/reference/cli', activeMatch: '/reference/' },
+      {
+        text: 'Integrations',
+        items: [
+          { text: 'CakePHP', link: 'https://github.com/dereuromark/cakephp-dto' },
+          { text: 'Laravel', link: 'https://github.com/php-collective/laravel-dto' },
+          { text: 'Symfony', link: 'https://github.com/php-collective/symfony-dto' },
+        ]
+      },
+      {
+        text: 'Links',
+        items: [
+          { text: 'Changelog', link: 'https://github.com/php-collective/dto/releases' },
+          { text: 'Packagist', link: 'https://packagist.org/packages/php-collective/dto' },
+        ]
+      }
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Introduction',
+          items: [
+            { text: 'Getting Started', link: '/guide/' },
+            { text: 'Motivation', link: '/guide/motivation' },
+            { text: 'Examples', link: '/guide/examples' },
+          ]
+        },
+        {
+          text: 'Configuration',
+          items: [
+            { text: 'Config Builder', link: '/guide/config-builder' },
+            { text: 'Validation', link: '/guide/validation' },
+            { text: 'Advanced Types', link: '/guide/advanced-types' },
+            { text: 'Shaped Arrays', link: '/guide/shaped-arrays' },
+            { text: 'Custom Casters', link: '/guide/custom-casters' },
+            { text: 'Collection Adapters', link: '/guide/collection-adapters' },
+          ]
+        },
+        {
+          text: 'Advanced',
+          items: [
+            { text: 'Advanced Patterns', link: '/guide/advanced-patterns' },
+            { text: 'Framework Integration', link: '/guide/framework-integration' },
+            { text: 'Separating Generated Code', link: '/guide/separating-generated-code' },
+            { text: 'Design Decisions', link: '/guide/design-decisions' },
+          ]
+        },
+        {
+          text: 'Operations',
+          items: [
+            { text: 'Performance', link: '/guide/performance' },
+            { text: 'Testing', link: '/guide/testing' },
+            { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+            { text: 'Migration', link: '/guide/migration' },
+          ]
+        }
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'CLI Reference', link: '/reference/cli' },
+            { text: 'TypeScript Generation', link: '/reference/typescript' },
+            { text: 'Schema Importer', link: '/reference/importer' },
+          ]
+        }
+      ]
+    },
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/php-collective/dto' }
+    ],
+
+    editLink: {
+      pattern: 'https://github.com/php-collective/dto/edit/master/docs/:path',
+      text: 'Edit this page on GitHub'
+    },
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © PHP Collective'
+    },
+
+    search: {
+      provider: 'local'
+    },
+
+    outline: {
+      level: [2, 3]
+    }
+  },
+
+  markdown: {
+    theme: {
+      light: 'github-light',
+      dark: 'github-dark'
+    }
+  }
+})

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,58 @@
+:root {
+  /* Purple brand colors */
+  --vp-c-brand-1: #7c3aed;
+  --vp-c-brand-2: #8b5cf6;
+  --vp-c-brand-3: #a78bfa;
+  --vp-c-brand-soft: rgba(124, 58, 237, 0.14);
+
+  /* Hero gradient */
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(135deg, #7c3aed 0%, #ec4899 100%);
+
+  --vp-home-hero-image-background-image: linear-gradient(135deg, #7c3aed 30%, #ec4899 70%);
+  --vp-home-hero-image-filter: blur(44px);
+}
+
+.dark {
+  --vp-c-brand-1: #a78bfa;
+  --vp-c-brand-2: #8b5cf6;
+  --vp-c-brand-3: #7c3aed;
+}
+
+/* Feature cards styling */
+.VPFeature {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.VPFeature:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px -8px rgba(124, 58, 237, 0.15);
+}
+
+/* Code block enhancements */
+.vp-doc div[class*='language-'] {
+  border-radius: 8px;
+}
+
+/* Better inline code styling */
+.vp-doc :not(pre) > code {
+  background-color: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+
+/* Homepage hero enhancements */
+.VPHero .text {
+  font-size: 1.1rem !important;
+  line-height: 1.6;
+  max-width: 600px;
+}
+
+/* Better table styling */
+.vp-doc table {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.vp-doc th {
+  background-color: var(--vp-c-brand-soft);
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default DefaultTheme

--- a/docs/guide/advanced-patterns.md
+++ b/docs/guide/advanced-patterns.md
@@ -1,0 +1,664 @@
+---
+title: Advanced Patterns
+---
+
+# Advanced Patterns
+
+This document covers advanced use cases and patterns for php-collective/dto.
+
+## Custom Collection Factories
+
+By default, collections use `ArrayObject`. You can customize this globally to use your framework's collection class.
+
+### Setting a Global Factory
+
+```php
+use PhpCollective\Dto\Dto\Dto;
+
+// CakePHP Collection
+Dto::setCollectionFactory(fn(array $items) => new \Cake\Collection\Collection($items));
+
+// Laravel Collection
+Dto::setCollectionFactory(fn(array $items) => collect($items));
+
+// Doctrine ArrayCollection
+Dto::setCollectionFactory(fn(array $items) => new \Doctrine\Common\Collections\ArrayCollection($items));
+```
+
+**Important:** Set the factory early in your application bootstrap, before any DTOs are instantiated.
+
+### Using Framework Collection Methods
+
+Once set, all DTO collections gain the framework's collection methods:
+
+```php
+// With Laravel collection factory
+Dto::setCollectionFactory(fn($items) => collect($items));
+
+$order = new OrderDto($data);
+
+// Now you can use Laravel collection methods
+$total = $order->getItems()
+    ->filter(fn($item) => $item->getQuantity() > 0)
+    ->sum(fn($item) => $item->getPrice() * $item->getQuantity());
+
+$productNames = $order->getItems()
+    ->pluck('name')
+    ->unique()
+    ->values();
+```
+
+### Resetting to Default
+
+```php
+// Reset to default ArrayObject
+Dto::setCollectionFactory(null);
+```
+
+## DTO Inheritance
+
+### Basic Inheritance
+
+```php
+// config/dto.php
+return Schema::create()
+    ->dto(Dto::create('BaseEntity')->fields(
+        Field::int('id')->required(),
+        Field::class('createdAt', \DateTimeImmutable::class),
+        Field::class('updatedAt', \DateTimeImmutable::class),
+    ))
+    ->dto(Dto::create('User')->extends('BaseEntity')->fields(
+        Field::string('email')->required(),
+        Field::string('name'),
+    ))
+    ->dto(Dto::create('Post')->extends('BaseEntity')->fields(
+        Field::string('title')->required(),
+        Field::string('content'),
+        Field::dto('author', 'User'),
+    ))
+    ->toArray();
+```
+
+Generated UserDto will have: `id`, `createdAt`, `updatedAt`, `email`, `name`
+
+### Immutable Inheritance
+
+Immutable DTOs can extend other immutable DTOs:
+
+```php
+Dto::immutable('BaseEvent')->fields(
+    Field::string('eventId')->required(),
+    Field::class('occurredAt', \DateTimeImmutable::class)->required(),
+)
+
+Dto::immutable('UserCreatedEvent')->extends('BaseEvent')->fields(
+    Field::int('userId')->required(),
+    Field::string('email')->required(),
+)
+```
+
+**Note:** An immutable DTO cannot extend a mutable DTO and vice versa.
+
+## Associative Collections
+
+### Basic Associative Collection
+
+```php
+Dto::create('Config')->fields(
+    Field::collection('settings', 'Setting')
+        ->singular('setting')
+        ->associative(),
+)
+```
+
+```php
+$config = new ConfigDto();
+
+// Add with string keys
+$config->addSetting('theme', new SettingDto(['value' => 'dark']));
+$config->addSetting('language', new SettingDto(['value' => 'en']));
+
+// Access by key
+$theme = $config->getSetting('theme');
+
+// Check existence
+if ($config->hasSetting('notifications')) {
+    // ...
+}
+
+// Remove by key
+$config->removeSetting('theme');
+```
+
+### Associative with Custom Key Field
+
+When your DTO has a natural key field:
+
+```php
+// Setting DTO with 'key' field
+Dto::create('Setting')->fields(
+    Field::string('key')->required(),
+    Field::string('value')->required(),
+)
+
+// Config with associative collection using 'key' as index
+Dto::create('Config')->fields(
+    Field::collection('settings', 'Setting')
+        ->singular('setting')
+        ->associative('key'),  // Use 'key' field as collection index
+)
+```
+
+```php
+$config = new ConfigDto([
+    'settings' => [
+        ['key' => 'theme', 'value' => 'dark'],
+        ['key' => 'lang', 'value' => 'en'],
+    ],
+]);
+
+// Access by the 'key' field value
+$theme = $config->getSetting('theme');
+echo $theme->getValue(); // 'dark'
+```
+
+## Factory Methods for Complex Instantiation
+
+### Static Factory Method
+
+For classes that use named constructors:
+
+```php
+Dto::create('Event')->fields(
+    Field::class('date', \DateTimeImmutable::class)
+        ->factory('createFromFormat'),
+)
+```
+
+The generator will call `DateTimeImmutable::createFromFormat()` when hydrating from array.
+
+### Custom Parser Factory
+
+```php
+// For a Money class with custom parsing
+Dto::create('Product')->fields(
+    Field::class('price', \Money\Money::class)
+        ->factory('Money\MoneyParser::parse'),
+)
+```
+
+### Factory with Interface
+
+```php
+// The DTO field uses the interface
+Field::class('logger', \Psr\Log\LoggerInterface::class)
+    ->factory('App\Factory\LoggerFactory::create')
+```
+
+## Nested DTO Patterns
+
+### Deep Nesting
+
+```php
+Dto::create('Company')->fields(
+    Field::string('name')->required(),
+    Field::collection('departments', 'Department')->singular('department'),
+)
+
+Dto::create('Department')->fields(
+    Field::string('name')->required(),
+    Field::collection('teams', 'Team')->singular('team'),
+)
+
+Dto::create('Team')->fields(
+    Field::string('name')->required(),
+    Field::collection('members', 'Employee')->singular('member'),
+)
+
+Dto::create('Employee')->fields(
+    Field::string('name')->required(),
+    Field::string('email')->required(),
+)
+```
+
+Access deeply nested data:
+
+```php
+$company = new CompanyDto($data);
+
+// Navigate the tree
+foreach ($company->getDepartments() as $dept) {
+    foreach ($dept->getTeams() as $team) {
+        foreach ($team->getMembers() as $employee) {
+            echo $employee->getEmail();
+        }
+    }
+}
+
+// Or use the read() helper for safe access
+$email = $company->read(['departments', 0, 'teams', 0, 'members', 0, 'email']);
+```
+
+### Self-Referencing DTOs
+
+For tree structures:
+
+```php
+Dto::create('Category')->fields(
+    Field::int('id')->required(),
+    Field::string('name')->required(),
+    Field::dto('parent', 'Category'),  // Nullable reference to self
+    Field::collection('children', 'Category')->singular('child'),
+)
+```
+
+```php
+$category = new CategoryDto([
+    'id' => 1,
+    'name' => 'Electronics',
+    'children' => [
+        ['id' => 2, 'name' => 'Phones', 'children' => []],
+        ['id' => 3, 'name' => 'Laptops', 'children' => []],
+    ],
+]);
+```
+
+## Partial Updates with touchedToArray()
+
+Track which fields were explicitly set:
+
+```php
+$user = new UserDto();
+$user->setEmail('new@example.com');
+// Only email was "touched"
+
+$changes = $user->touchedToArray();
+// ['email' => 'new@example.com']
+
+// Use for partial database updates
+$this->repository->update($userId, $changes);
+```
+
+### Form Handling Pattern
+
+```php
+public function updateProfile(Request $request, int $userId): Response
+{
+    // Load existing data
+    $existing = $this->userRepository->find($userId);
+
+    // Create DTO and apply only submitted fields
+    $dto = new UserDto();
+
+    if ($request->has('email')) {
+        $dto->setEmail($request->input('email'));
+    }
+    if ($request->has('name')) {
+        $dto->setName($request->input('name'));
+    }
+
+    // Get only the fields that were actually set
+    $changes = $dto->touchedToArray();
+
+    if (empty($changes)) {
+        return new Response('No changes');
+    }
+
+    $this->userRepository->update($userId, $changes);
+
+    return new Response('Updated');
+}
+```
+
+## Immutable Event Sourcing Pattern
+
+```php
+// Base event
+Dto::immutable('DomainEvent')->fields(
+    Field::string('eventId')->required(),
+    Field::string('aggregateId')->required(),
+    Field::class('occurredAt', \DateTimeImmutable::class)->required(),
+    Field::int('version')->required(),
+)
+
+// Specific events
+Dto::immutable('OrderPlaced')->extends('DomainEvent')->fields(
+    Field::dto('order', 'Order')->required(),
+    Field::string('customerId')->required(),
+)
+
+Dto::immutable('OrderShipped')->extends('DomainEvent')->fields(
+    Field::string('trackingNumber')->required(),
+    Field::string('carrier')->required(),
+)
+```
+
+```php
+// Events are immutable - create new instances for modifications
+$event = new OrderPlacedDto([
+    'eventId' => Uuid::uuid4()->toString(),
+    'aggregateId' => $orderId,
+    'occurredAt' => new DateTimeImmutable(),
+    'version' => 1,
+    'order' => $orderDto,
+    'customerId' => $customerId,
+]);
+
+// To "modify", create new event with changes
+$correctedEvent = $event->withVersion(2);
+```
+
+## API Response Transformation
+
+### Different Output Formats
+
+```php
+$userDto = new UserDto($data);
+
+// Default camelCase for JavaScript frontend
+$jsonResponse = $userDto->toArray();
+// ['firstName' => 'John', 'lastName' => 'Doe']
+
+// Snake case for Python/Ruby APIs
+$snakeResponse = $userDto->toArray(UserDto::TYPE_UNDERSCORED);
+// ['first_name' => 'John', 'last_name' => 'Doe']
+
+// Dash case for URL parameters
+$dashResponse = $userDto->toArray(UserDto::TYPE_DASHED);
+// ['first-name' => 'John', 'last-name' => 'Doe']
+```
+
+### Input Normalization
+
+```php
+// Accept any format from external APIs
+public function importUser(array $externalData, string $format): UserDto
+{
+    $dto = new UserDto();
+
+    $type = match ($format) {
+        'snake' => UserDto::TYPE_UNDERSCORED,
+        'dash' => UserDto::TYPE_DASHED,
+        default => UserDto::TYPE_DEFAULT,
+    };
+
+    $dto->fromArray($externalData, false, $type);
+
+    return $dto;
+}
+```
+
+## Conditional Field Inclusion
+
+Using the fields() method to check what's set:
+
+```php
+$user = new UserDto($data);
+
+// Get list of all fields
+$allFields = $user->fields();
+// ['id', 'name', 'email', 'phone', 'address', ...]
+
+// Build response with only non-null fields
+$response = [];
+foreach ($user->fields() as $field) {
+    $getter = 'get' . ucfirst($field);
+    $value = $user->$getter();
+    if ($value !== null) {
+        $response[$field] = $value;
+    }
+}
+```
+
+## Cloning and Isolation
+
+### Deep Clone
+
+```php
+$original = new OrderDto($data);
+
+// Deep clone - all nested DTOs are also cloned
+$clone = $original->clone();
+
+// Modify clone without affecting original
+$clone->getCustomer()->setEmail('different@example.com');
+
+// Original is unchanged
+assert($original->getCustomer()->getEmail() !== 'different@example.com');
+```
+
+### Comparison
+
+```php
+$dto1 = new UserDto(['id' => 1, 'name' => 'John']);
+$dto2 = new UserDto(['id' => 1, 'name' => 'John']);
+
+// Compare by value using toArray()
+$areEqual = $dto1->toArray() === $dto2->toArray(); // true
+```
+
+## Data Transformation Patterns
+
+Unlike some runtime DTO libraries that offer "data pipes" for transforming data before/after hydration, php-collective/dto uses code generation. Here are patterns to achieve similar functionality.
+
+### Pre-Processing (Transform Before DTO Creation)
+
+Transform input data before passing to the DTO constructor:
+
+```php
+class UserDtoFactory
+{
+    public static function fromRequest(array $data): UserDto
+    {
+        // Normalize/transform data before DTO creation
+        $normalized = [
+            'name' => trim($data['name'] ?? ''),
+            'email' => strtolower(trim($data['email'] ?? '')),
+            'phone' => self::normalizePhone($data['phone'] ?? null),
+            'createdAt' => new DateTimeImmutable($data['created_at'] ?? 'now'),
+        ];
+
+        return new UserDto($normalized);
+    }
+
+    private static function normalizePhone(?string $phone): ?string
+    {
+        if ($phone === null) {
+            return null;
+        }
+        // Remove non-digits
+        return preg_replace('/[^0-9]/', '', $phone);
+    }
+}
+
+// Usage
+$dto = UserDtoFactory::fromRequest($request->all());
+```
+
+### Post-Processing (Transform After DTO Creation)
+
+Apply transformations after the DTO is created:
+
+```php
+class UserDtoTransformer
+{
+    public static function withDefaults(UserDto $dto): UserDto
+    {
+        if (!$dto->hasRole()) {
+            $dto->setRole('user');
+        }
+        if (!$dto->hasCreatedAt()) {
+            $dto->setCreatedAt(new DateTimeImmutable());
+        }
+        return $dto;
+    }
+
+    public static function sanitize(UserDto $dto): UserDto
+    {
+        $dto->setName(htmlspecialchars($dto->getName() ?? ''));
+        $dto->setBio(strip_tags($dto->getBio() ?? ''));
+        return $dto;
+    }
+}
+
+// Usage
+$dto = new UserDto($data);
+$dto = UserDtoTransformer::withDefaults($dto);
+$dto = UserDtoTransformer::sanitize($dto);
+```
+
+### Pipeline Pattern
+
+Chain multiple transformations:
+
+```php
+class DtoPipeline
+{
+    /** @var array<callable> */
+    private array $pipes = [];
+
+    public function pipe(callable $transformation): self
+    {
+        $this->pipes[] = $transformation;
+        return $this;
+    }
+
+    public function process(array $data, string $dtoClass): object
+    {
+        // Pre-processing pipes on raw data
+        foreach ($this->pipes as $pipe) {
+            if ($this->isPreProcessor($pipe)) {
+                $data = $pipe($data);
+            }
+        }
+
+        $dto = new $dtoClass($data);
+
+        // Post-processing pipes on DTO
+        foreach ($this->pipes as $pipe) {
+            if ($this->isPostProcessor($pipe)) {
+                $dto = $pipe($dto);
+            }
+        }
+
+        return $dto;
+    }
+}
+
+// Usage
+$pipeline = (new DtoPipeline())
+    ->pipe(fn(array $data) => array_map('trim', $data))  // Pre: trim all strings
+    ->pipe(fn(UserDto $dto) => $dto->setCreatedAt(new DateTimeImmutable()));  // Post: set timestamp
+
+$dto = $pipeline->process($inputData, UserDto::class);
+```
+
+### Service Layer Approach
+
+Encapsulate transformation logic in a service:
+
+```php
+class UserService
+{
+    public function createFromRegistration(array $formData): UserDto
+    {
+        // Pre-process
+        $data = $this->normalizeRegistrationData($formData);
+
+        // Create DTO
+        $dto = new UserDto($data);
+
+        // Post-process
+        $dto->setRole('user');
+        $dto->setStatus('pending');
+        $dto->setCreatedAt(new DateTimeImmutable());
+
+        return $dto;
+    }
+
+    public function createFromApiImport(array $apiData): UserDto
+    {
+        // Different transformation for API imports
+        $data = $this->mapApiFields($apiData);
+        $dto = new UserDto($data, ignoreMissing: true);
+        $dto->setSource('api');
+
+        return $dto;
+    }
+
+    private function normalizeRegistrationData(array $data): array
+    {
+        return [
+            'name' => ucwords(strtolower(trim($data['name'] ?? ''))),
+            'email' => strtolower(trim($data['email'] ?? '')),
+            'password' => $data['password'] ?? null,
+        ];
+    }
+
+    private function mapApiFields(array $apiData): array
+    {
+        return [
+            'name' => $apiData['full_name'] ?? $apiData['name'] ?? '',
+            'email' => $apiData['email_address'] ?? $apiData['email'] ?? '',
+            'externalId' => $apiData['id'] ?? null,
+        ];
+    }
+}
+```
+
+### Output Transformation
+
+Transform DTO output for different contexts:
+
+```php
+class UserDtoPresenter
+{
+    public static function forApi(UserDto $dto): array
+    {
+        $data = $dto->toArray(UserDto::TYPE_UNDERSCORED);
+
+        // Remove sensitive fields
+        unset($data['password'], $data['api_key']);
+
+        // Add computed fields
+        $data['full_name'] = $dto->getFirstName() . ' ' . $dto->getLastName();
+        $data['avatar_url'] = self::avatarUrl($dto->getEmail());
+
+        return $data;
+    }
+
+    public static function forAdmin(UserDto $dto): array
+    {
+        $data = $dto->toArray();
+
+        // Include audit fields for admin view
+        $data['lastLoginFormatted'] = $dto->getLastLogin()?->format('Y-m-d H:i');
+        $data['accountAge'] = $dto->getCreatedAt()?->diff(new DateTimeImmutable())->days;
+
+        return $data;
+    }
+
+    private static function avatarUrl(?string $email): string
+    {
+        if (!$email) {
+            return '/images/default-avatar.png';
+        }
+        return 'https://gravatar.com/avatar/' . md5(strtolower($email));
+    }
+}
+
+// Usage
+return response()->json(UserDtoPresenter::forApi($userDto));
+```
+
+### Why No Built-in Pipes?
+
+php-collective/dto intentionally keeps DTOs as pure data containers without transformation logic:
+
+1. **Separation of concerns**: DTOs hold data; services transform it
+2. **Testability**: Transformation logic can be unit tested independently
+3. **Flexibility**: Different contexts can use different transformations
+4. **Performance**: No overhead from pipe chain evaluation
+5. **Clarity**: Explicit transformation code is easier to understand and debug
+
+The patterns above achieve the same results while keeping your code explicit and maintainable.

--- a/docs/guide/advanced-types.md
+++ b/docs/guide/advanced-types.md
@@ -1,0 +1,631 @@
+---
+title: Advanced Type Support
+---
+
+# Advanced Type Support
+
+This document covers advanced type features including union types, enums, custom classes, generics, and complex type scenarios.
+
+## Type Overview
+
+| Type Category | Examples | PHP Type Hint |
+|---------------|----------|---------------|
+| Scalar | `string`, `int`, `float`, `bool` | Native types |
+| Special | `mixed`, `array`, `object` | Native types |
+| Union | `int\|string`, `int\|float\|string` | Union types (PHP 8.0+) |
+| DTO Reference | `User`, `Address` | Generated DTO class |
+| Class | `\DateTimeImmutable`, `\Money\Money` | FQCN |
+| Enum | `\App\Enum\Status` | Enum class |
+| Array | `string[]`, `int[]`, `User[]` | `array` with PHPDoc |
+| Collection | `Item[]` with `collection: true` | `\ArrayObject` with PHPDoc |
+
+## Union Types
+
+Union types allow a field to accept multiple types. Supported in PHP 8.0+.
+
+### Configuration
+
+#### PHP Builder
+
+```php
+use PhpCollective\Dto\Config\Field;
+
+// Two types
+Field::union('id', 'int', 'string')
+
+// Three types
+Field::union('value', 'int', 'float', 'string')
+
+// With modifiers
+Field::union('id', 'int', 'string')->required()
+
+// Alternative using of()
+Field::of('id', 'int|string')
+```
+
+#### PHP Array
+
+```php
+'id' => [
+    'type' => 'int|string',
+],
+'value' => [
+    'type' => 'int|float|string',
+    'required' => true,
+],
+```
+
+#### XML
+
+```xml
+<field name="id" type="int|string"/>
+<field name="value" type="int|float|string" required="true"/>
+```
+
+#### YAML
+
+```yaml
+id:
+  type: 'int|string'
+value:
+  type: 'int|float|string'
+  required: true
+```
+
+#### NEON
+
+```neon
+id:
+    type: int|string
+value:
+    type: int|float|string
+    required: true
+```
+
+### Generated Code
+
+```php
+// Property
+protected int|string|null $id = null;
+
+// Getter
+public function getId(): int|string|null
+{
+    return $this->id;
+}
+
+// Setter
+public function setId(int|string|null $id): self
+{
+    $this->id = $id;
+    $this->_touchedFields['id'] = true;
+    return $this;
+}
+```
+
+### Nullable Union Types
+
+Union types become nullable automatically unless `required: true`:
+
+```php
+// Not required (default) - nullable
+Field::union('id', 'int', 'string')
+// Type: int|string|null
+
+// Required - not nullable
+Field::union('id', 'int', 'string')->required()
+// Type: int|string
+```
+
+## Enums
+
+Both backed enums and unit enums are supported.
+
+### Quick Examples
+
+Backed enum from string (recommended):
+
+```php
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Confirmed = 'confirmed';
+}
+
+$dto = new OrderDto(['status' => 'confirmed']);
+$dto->getStatus(); // OrderStatus::Confirmed
+$dto->toArray();   // ['status' => 'confirmed']
+```
+
+Unit enum from case name:
+
+```php
+enum Priority
+{
+    case High;
+    case Low;
+}
+
+$dto = new TaskDto(['priority' => 'High']);
+$dto->getPriority(); // Priority::High
+```
+
+### Backed Enums (Recommended)
+
+Backed enums have scalar values and are the most common:
+
+```php
+// Your enum
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Confirmed = 'confirmed';
+    case Shipped = 'shipped';
+    case Delivered = 'delivered';
+}
+```
+
+#### Configuration
+
+```php
+// PHP Builder
+Field::enum('status', \App\Enum\OrderStatus::class)
+
+// PHP Array
+'status' => [
+    'type' => '\App\Enum\OrderStatus',
+],
+```
+
+```xml
+<!-- XML -->
+<field name="status" type="\App\Enum\OrderStatus"/>
+```
+
+```yaml
+# YAML
+status:
+  type: '\App\Enum\OrderStatus'
+```
+
+#### Usage
+
+```php
+// Set with enum instance
+$order->setStatus(OrderStatus::Pending);
+
+// Set from backing value (auto-converted)
+$order = new OrderDto(['status' => 'confirmed']);
+$order->getStatus(); // OrderStatus::Confirmed
+
+// toArray() returns backing value
+$order->toArray(); // ['status' => 'confirmed']
+```
+
+### Unit Enums
+
+Unit enums have no backing value:
+
+```php
+enum Priority
+{
+    case Low;
+    case Medium;
+    case High;
+}
+```
+
+#### Usage
+
+```php
+// Set with enum instance
+$task->setPriority(Priority::High);
+
+// Set from case name (string)
+$task = new TaskDto(['priority' => 'High']);
+$task->getPriority(); // Priority::High
+
+// toArray() returns case name
+$task->toArray(); // ['priority' => 'High']
+```
+
+### Int-Backed Enums
+
+```php
+enum HttpStatus: int
+{
+    case Ok = 200;
+    case NotFound = 404;
+    case ServerError = 500;
+}
+
+// Set from int value
+$response = new ResponseDto(['status' => 200]);
+$response->getStatus(); // HttpStatus::Ok
+```
+
+## Custom Classes
+
+Any PHP class can be used as a field type.
+
+### Basic Class Fields
+
+```php
+// PHP Builder
+Field::class('createdAt', \DateTimeImmutable::class)
+Field::class('money', \Money\Money::class)
+
+// PHP Array
+'createdAt' => [
+    'type' => '\DateTimeImmutable',
+],
+```
+
+```xml
+<!-- XML -->
+<field name="createdAt" type="\DateTimeImmutable"/>
+```
+
+### With Factory Method
+
+When a class needs custom instantiation:
+
+```php
+Field::class('date', \DateTimeImmutable::class)
+    ->factory('createFromFormat')
+
+Field::class('money', \Money\Money::class)
+    ->factory('fromArray')
+
+// External factory
+Field::class('price', \App\ValueObject\Price::class)
+    ->factory('App\Factory\PriceFactory::create')
+```
+
+### With Serialization
+
+Control how objects are converted in `toArray()`:
+
+```php
+// Call toArray() method
+Field::class('dimensions', Dimensions::class)
+    ->serialize('array')
+
+// Call __toString() method
+Field::class('sku', Sku::class)
+    ->serialize('string')
+
+// Full round-trip with FromArrayToArrayInterface
+Field::class('metadata', Metadata::class)
+    ->serialize('FromArrayToArray')
+```
+
+### Constructor-Based Creation
+
+If no factory is specified and the class has a single-argument constructor, it will be called automatically:
+
+```php
+class Wrapper
+{
+    public function __construct(public mixed $value) {}
+}
+
+// No factory needed - constructor called with the value
+Field::class('wrapper', Wrapper::class)
+```
+
+## DTO References
+
+Reference other DTOs in your schema:
+
+### Simple Reference
+
+```php
+// PHP Builder
+Field::dto('address', 'Address')
+Field::dto('author', 'User')
+
+// PHP Array
+'address' => [
+    'type' => 'Address',
+],
+```
+
+```xml
+<!-- XML -->
+<field name="address" type="Address"/>
+```
+
+The generator automatically:
+- Resolves the DTO class name (adds namespace and suffix)
+- Handles nested array-to-DTO conversion
+- Supports deep cloning
+
+### Nested DTO Conversion
+
+```php
+$order = new OrderDto([
+    'customer' => [
+        'name' => 'John',
+        'email' => 'john@example.com',
+    ],
+]);
+
+// Nested array automatically converted to CustomerDto
+$order->getCustomer()->getName(); // 'John'
+```
+
+## Array Types
+
+### Typed Arrays
+
+Arrays with element type hints:
+
+```php
+// PHP Builder
+Field::array('tags', 'string')      // string[]
+Field::array('scores', 'int')       // int[]
+Field::array('users', 'User')       // User[] (DTO array)
+
+// PHP Array
+'tags' => 'string[]',
+'scores' => ['type' => 'int[]'],
+```
+
+```xml
+<!-- XML -->
+<field name="tags" type="string[]"/>
+<field name="users" type="User[]"/>
+```
+
+### Generated PHPDoc
+
+Typed arrays generate generic PHPDoc for static analysis:
+
+```php
+/**
+ * @var array<int, string>
+ */
+protected array $tags = [];
+
+/**
+ * @return array<int, string>
+ */
+public function getTags(): array
+```
+
+### Untyped Arrays
+
+Plain arrays without element type:
+
+```php
+Field::array('data')  // Just 'array'
+
+// PHP Array
+'data' => 'array',
+```
+
+## Collections
+
+Collections provide `add*()`, `get*()`, `has*()` methods for managing items.
+
+### Basic Collection
+
+```php
+// PHP Builder
+Field::collection('items', 'Item')->singular('item')
+
+// PHP Array
+'items' => [
+    'type' => 'Item[]',
+    'collection' => true,
+    'singular' => 'item',
+],
+```
+
+```xml
+<!-- XML -->
+<field name="items" type="Item[]" collection="true" singular="item"/>
+```
+
+### Generated Methods
+
+```php
+// Add item
+$cart->addItem(new ItemDto(['name' => 'Widget']));
+
+// Get all items (returns ArrayObject)
+$items = $cart->getItems();
+
+// Check if has items
+if ($cart->hasItems()) { ... }
+```
+
+### Associative Collections
+
+Keyed access to collection items:
+
+```php
+// PHP Builder
+Field::collection('settings', 'Setting')
+    ->singular('setting')
+    ->associative()
+
+// With custom key field
+Field::collection('products', 'Product')
+    ->singular('product')
+    ->associative('sku')
+```
+
+```xml
+<!-- XML -->
+<field name="settings" type="Setting[]" collection="true"
+       singular="setting" associative="true"/>
+<field name="products" type="Product[]" collection="true"
+       singular="product" associative="true" key="sku"/>
+```
+
+### Generated Methods (Associative)
+
+```php
+// Add with key
+$config->addSetting('theme', new SettingDto(['value' => 'dark']));
+
+// Get by key
+$theme = $config->getSetting('theme');
+
+// Check by key
+if ($config->hasSetting('notifications')) { ... }
+```
+
+### Custom Collection Type
+
+Override the default `\ArrayObject`:
+
+```php
+// PHP Array
+'items' => [
+    'type' => 'Item[]',
+    'collection' => true,
+    'singular' => 'item',
+    'collectionType' => '\Doctrine\Common\Collections\ArrayCollection',
+],
+```
+
+```xml
+<!-- XML -->
+<field name="items" type="Item[]" collection="true"
+       singular="item" collectionType="\Doctrine\Common\Collections\ArrayCollection"/>
+```
+
+## PHPDoc Generics
+
+The generator creates generic PHPDoc annotations for static analysis tools (PHPStan, Psalm):
+
+### Array Generics
+
+```php
+// Configuration: type="string[]"
+// Generated:
+/**
+ * @var array<int, string>
+ */
+protected array $tags = [];
+
+// Associative array
+/**
+ * @var array<string, SettingDto>
+ */
+protected array $settings = [];
+```
+
+### Collection Generics
+
+```php
+// Configuration: type="Item[]" collection="true"
+// Generated:
+/**
+ * @var \ArrayObject<int, ItemDto>
+ */
+protected ?\ArrayObject $items = null;
+
+// Associative collection
+/**
+ * @var \ArrayObject<string, ProductDto>
+ */
+protected ?\ArrayObject $products = null;
+```
+
+## Complex Type Examples
+
+### E-commerce Order
+
+```php
+return Schema::create()
+    ->dto(Dto::create('Order')->fields(
+        Field::int('id')->required(),
+        Field::enum('status', \App\Enum\OrderStatus::class)->required(),
+        Field::dto('customer', 'Customer')->required(),
+        Field::dto('shippingAddress', 'Address'),
+        Field::dto('billingAddress', 'Address'),
+        Field::collection('items', 'OrderItem')->singular('item'),
+        Field::class('total', \Money\Money::class)
+            ->factory('fromArray')
+            ->serialize('array'),
+        Field::class('createdAt', \DateTimeImmutable::class)->required(),
+        Field::class('shippedAt', \DateTimeImmutable::class),
+    ))
+    ->dto(Dto::create('OrderItem')->fields(
+        Field::union('productId', 'int', 'string')->required(),
+        Field::string('name')->required(),
+        Field::int('quantity')->required()->default(1),
+        Field::class('unitPrice', \Money\Money::class)
+            ->factory('fromArray')
+            ->serialize('array'),
+    ))
+    ->toArray();
+```
+
+### API Response with Metadata
+
+```php
+return Schema::create()
+    ->dto(Dto::create('ApiResponse')->fields(
+        Field::bool('success')->required()->default(true),
+        Field::mixed('data'),
+        Field::array('errors', 'string'),
+        Field::dto('pagination', 'Pagination'),
+        Field::array('meta'),  // Untyped for flexibility
+    ))
+    ->dto(Dto::create('Pagination')->fields(
+        Field::int('page')->required()->default(1),
+        Field::int('perPage')->required()->default(20),
+        Field::int('total')->required(),
+        Field::int('totalPages')->required(),
+        Field::bool('hasMore')->required(),
+    ))
+    ->toArray();
+```
+
+### Event Sourcing
+
+```php
+return Schema::create()
+    ->dto(Dto::immutable('DomainEvent')->fields(
+        Field::string('eventId')->required(),
+        Field::string('aggregateId')->required(),
+        Field::int('version')->required(),
+        Field::class('occurredAt', \DateTimeImmutable::class)->required(),
+        Field::array('payload'),
+    ))
+    ->dto(Dto::immutable('OrderPlaced')->extends('DomainEvent')->fields(
+        Field::dto('order', 'Order')->required(),
+    ))
+    ->dto(Dto::immutable('OrderShipped')->extends('DomainEvent')->fields(
+        Field::string('trackingNumber')->required(),
+        Field::string('carrier')->required(),
+    ))
+    ->toArray();
+```
+
+## Type Coercion
+
+The library performs automatic type coercion in certain cases:
+
+| Input Type | Target Type | Behavior |
+|------------|-------------|----------|
+| `string` | Backed Enum | Calls `Enum::tryFrom($value)` |
+| `int` | Backed Enum (int) | Calls `Enum::tryFrom($value)` |
+| `string` | Unit Enum | Calls `constant(Enum::$value)` |
+| `array` | DTO | Calls `Dto::createFromArray($value)` |
+| `array` | Class with `fromArray` | Calls factory method |
+| `mixed` | Class with constructor | Calls `new Class($value)` |
+
+## Best Practices
+
+1. **Use specific types** - Avoid `mixed` when a more specific type is possible
+2. **Prefer backed enums** - They serialize cleanly and work with databases
+3. **Use union types sparingly** - Too many types reduce type safety
+4. **Add factories for value objects** - Ensure clean instantiation
+5. **Configure serialization** - Ensure `toArray()` produces expected output
+6. **Leverage PHPDoc generics** - Let static analysis tools help catch errors

--- a/docs/guide/collection-adapters.md
+++ b/docs/guide/collection-adapters.md
@@ -1,0 +1,117 @@
+---
+title: Collection Adapters
+---
+
+# Collection Adapters
+
+The DTO library supports different collection types through a pluggable adapter system. This allows framework-specific collections (CakePHP, Laravel, Doctrine) to be used without maintaining separate template files.
+
+## Why Adapters?
+
+Different collection implementations have different APIs:
+
+| Collection Type | Append Method | Mutability |
+|----------------|---------------|------------|
+| `\ArrayObject` | `append($item)` | Mutable (modifies in place) |
+| `\Cake\Collection\Collection` | `appendItem($item)` | Immutable (returns new instance) |
+| `\Illuminate\Support\Collection` | `push($item)` | Mutable |
+| `\Doctrine\Common\Collections\ArrayCollection` | `add($item)` | Mutable |
+
+Without adapters, each framework would need its own template files. With adapters, we have a single set of templates that delegate to the appropriate adapter.
+
+## Default Adapter
+
+The library includes `ArrayObjectAdapter` as the default, which handles PHP's built-in `\ArrayObject`:
+
+```php
+use PhpCollective\Dto\Collection\ArrayObjectAdapter;
+
+// This is the default - no registration needed
+```
+
+## Framework Integration
+
+Framework-specific adapters should be provided by their respective wrapper packages. For example:
+
+- **CakePHP**: `cakephp-dto` provides `CakeCollectionAdapter`
+- **Laravel**: A `laravel-dto` package would provide `LaravelCollectionAdapter`
+
+This keeps the core library framework-agnostic while allowing full customization.
+
+## Creating Custom Adapters
+
+Implement `CollectionAdapterInterface` for your collection type:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace App\Dto\Collection;
+
+use PhpCollective\Dto\Collection\CollectionAdapterInterface;
+
+class CakeCollectionAdapter implements CollectionAdapterInterface
+{
+    public function getCollectionClass(): string
+    {
+        return '\\Cake\\Collection\\Collection';
+    }
+
+    public function isImmutable(): bool
+    {
+        return true; // Cake collections are immutable
+    }
+
+    public function getAppendMethod(): string
+    {
+        return 'appendItem';
+    }
+
+    public function getCreateEmptyCode(string $typeHint): string
+    {
+        return "new {$typeHint}([])";
+    }
+
+    public function getAppendCode(string $collectionVar, string $itemVar): string
+    {
+        // Cake's appendItem() returns a new Collection instance
+        return "{$collectionVar} = {$collectionVar}->appendItem({$itemVar});";
+    }
+}
+```
+
+Register it at bootstrap:
+
+```php
+// CakePHP plugin bootstrap
+use PhpCollective\Dto\Collection\CollectionAdapterRegistry;
+
+CollectionAdapterRegistry::register(new CakeCollectionAdapter());
+```
+
+## How It Works
+
+During code generation, the `TwigRenderer` makes adapters available to templates:
+
+```twig
+{# In method_add.twig #}
+{% set adapter = getCollectionAdapter(collectionType) %}
+
+public function add{{ singular }}(${{ singular }}) {
+    if ($this->{{ name }} === null) {
+        $this->{{ name }} = {{ adapter.createEmptyCode(typeHint) }};
+    }
+
+    {{ adapter.appendCode('$this->' ~ name, '$' ~ singular) }}
+    $this->_touchedFields[static::FIELD_{{ name }}] = true;
+
+    return $this;
+}
+```
+
+## Benefits
+
+1. **Clean separation of concerns** - Core library stays framework-agnostic
+2. **No phantom dependencies** - Core doesn't reference framework classes
+3. **Easy extensibility** - Add support for new collection types without modifying core
+4. **Framework ownership** - Each framework wrapper owns its adapter implementation

--- a/docs/guide/config-builder.md
+++ b/docs/guide/config-builder.md
@@ -1,0 +1,605 @@
+---
+title: Configuration Builder API
+---
+
+# Configuration Builder API
+
+The configuration builder provides a fluent, type-safe way to define DTO schemas with full IDE autocomplete support.
+
+## Quick Start
+
+```php
+<?php
+// config/dto.php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\Field;
+use PhpCollective\Dto\Config\Schema;
+
+return Schema::create()
+    ->dto(Dto::create('User')->fields(
+        Field::int('id')->required(),
+        Field::string('email')->required(),
+        Field::string('name'),
+        Field::bool('active')->default(true),
+    ))
+    ->dto(Dto::create('Address')->fields(
+        Field::string('street'),
+        Field::string('city')->required(),
+        Field::string('country')->default('USA'),
+    ))
+    ->toArray();
+```
+
+## Why Use the Builder?
+
+The builder API offers several advantages over plain arrays:
+
+| Feature | Array Config | Builder API |
+|---------|-------------|-------------|
+| IDE Autocomplete | No | Yes |
+| Typo Prevention | No | Yes (method names) |
+| Type Hints | No | Yes |
+| Discoverability | Low | High (see all options via IDE) |
+
+## Field Types
+
+### Scalar Types
+
+```php
+Field::string('name')      // string
+Field::int('count')        // int
+Field::float('price')      // float
+Field::bool('active')      // bool
+Field::mixed('data')       // mixed
+```
+
+### Arrays
+
+```php
+Field::array('tags')              // array
+Field::array('roles', 'string')   // string[]
+Field::array('scores', 'int')     // int[]
+```
+
+### DTO References
+
+```php
+Field::dto('address', 'Address')    // Reference to AddressDto
+Field::dto('author', 'User')        // Reference to UserDto
+```
+
+### Collections
+
+```php
+// ArrayObject collection with singular add method
+Field::collection('items', 'Item')->singular('item')
+
+// Associative collection
+Field::collection('users', 'User')
+    ->singular('user')
+    ->associative()
+
+// Associative with custom key
+Field::collection('products', 'Product')
+    ->singular('product')
+    ->associative('sku')
+```
+
+### Classes and Value Objects
+
+```php
+Field::class('createdAt', \DateTimeImmutable::class)
+Field::class('money', \Money\Money::class)->factory('fromArray')
+```
+
+### Enums
+
+```php
+Field::enum('status', \App\Enum\OrderStatus::class)
+```
+
+### Union Types
+
+```php
+Field::union('id', 'int', 'string')              // int|string
+Field::union('value', 'int', 'float', 'string')  // int|float|string
+Field::union('id', 'int', 'string')->required()  // Required union type
+
+// Or using of() for explicit union strings
+Field::of('mixed', 'int|string|null')
+```
+
+### Custom Types
+
+```php
+Field::of('custom', 'CustomType')
+```
+
+## Field Modifiers
+
+### Required Fields
+
+```php
+Field::string('email')->required()
+```
+
+### Default Values
+
+```php
+Field::bool('active')->default(true)
+Field::string('status')->default('pending')
+Field::int('count')->default(0)
+```
+
+### Deprecated Fields
+
+```php
+Field::string('oldField')->deprecated('Use newField instead')
+```
+
+### Factory Methods
+
+For classes that need custom instantiation:
+
+```php
+Field::class('date', \DateTimeImmutable::class)->factory('createFromFormat')
+Field::class('money', \Money\Money::class)->factory('Money\Parser::parse')
+```
+
+### Serialization
+
+Control how complex objects are serialized in `toArray()`:
+
+```php
+// Serialize to array using toArray() method
+Field::class('data', MyClass::class)->serialize('array')
+
+// Serialize to string using __toString() method
+Field::class('value', Stringable::class)->serialize('string')
+
+// Use FromArrayToArrayInterface for both directions
+Field::class('config', ConfigObject::class)->serialize('FromArrayToArray')
+```
+
+**Serialization modes:**
+
+| Mode | Method Called | Use When |
+|------|---------------|----------|
+| `array` | `->toArray()` | Object has toArray() method |
+| `string` | `->__toString()` | Object implements Stringable |
+| `FromArrayToArray` | `->toArray()` + `::fromArray()` | Object has both methods for round-trip |
+
+**Example with custom class:**
+
+```php
+// Your value object
+class Money implements \Stringable
+{
+    public function __construct(
+        public readonly int $amount,
+        public readonly string $currency,
+    ) {}
+
+    public function toArray(): array
+    {
+        return ['amount' => $this->amount, 'currency' => $this->currency];
+    }
+
+    public function __toString(): string
+    {
+        return $this->amount . ' ' . $this->currency;
+    }
+}
+
+// Configuration
+Field::class('price', Money::class)->serialize('array')
+// toArray() returns: ['price' => ['amount' => 1000, 'currency' => 'USD']]
+
+Field::class('priceDisplay', Money::class)->serialize('string')
+// toArray() returns: ['priceDisplay' => '1000 USD']
+```
+
+### Transforms
+
+Apply a callable to transform values before hydration or after serialization:
+
+```php
+Field::string('email')->transformFrom('App\\Transform\\Email::normalize')
+Field::string('email')->transformTo('App\\Transform\\Email::mask')
+```
+
+For collections, transforms are applied to each element.
+
+### Property Mapping
+
+Map field names between different formats when reading from or writing to arrays:
+
+```php
+// Map from different input key
+Field::string('emailAddress')->mapFrom('email')
+
+// Map to different output key
+Field::string('emailAddress')->mapTo('email_address')
+
+// Both directions
+Field::string('emailAddress')->mapFrom('email')->mapTo('email_address')
+```
+
+**Use cases:**
+
+| Scenario | Configuration |
+|----------|--------------|
+| API uses snake_case, DTO uses camelCase | `mapFrom('user_name')` |
+| Database column differs from property | `mapFrom('usr_email')` |
+| Output to legacy system with different naming | `mapTo('EMAIL_ADDRESS')` |
+| Complete bi-directional mapping | `mapFrom('email')->mapTo('email_address')` |
+
+**Example: External API Integration**
+
+```php
+// External API returns: {"user_name": "John", "created_at": "2024-01-01"}
+// Your DTO uses camelCase internally
+
+Dto::create('ApiUser')->fields(
+    Field::string('userName')->mapFrom('user_name'),
+    Field::string('createdAt')->mapFrom('created_at')->mapTo('timestamp'),
+)
+
+// Usage
+$dto = new ApiUserDto(['user_name' => 'John', 'created_at' => '2024-01-01']);
+echo $dto->getUserName(); // 'John'
+
+$dto->toArray();
+// ['userName' => 'John', 'timestamp' => '2024-01-01']
+```
+
+**Array syntax:**
+
+```php
+'ApiUser' => [
+    'fields' => [
+        'userName' => [
+            'type' => 'string',
+            'mapFrom' => 'user_name',
+            'mapTo' => 'username',
+        ],
+    ],
+],
+```
+
+Note: This should be used carefully. The more renaming, the harder it is to follow this later on.
+
+## DTO Options
+
+### Basic DTO
+
+```php
+Dto::create('User')->fields(
+    Field::int('id')->required(),
+    Field::string('name'),
+)
+```
+
+### Immutable DTO
+
+```php
+Dto::immutable('Event')->fields(
+    Field::int('id')->required(),
+    Field::class('occurredAt', \DateTimeImmutable::class)->required(),
+)
+
+// Or using the modifier
+Dto::create('Event')->asImmutable()->fields(...)
+```
+
+### DTO Inheritance
+
+```php
+Dto::create('FlyingCar')->extends('Car')->fields(
+    Field::int('maxAltitude')->default(1000),
+    Field::bool('canHover')->default(false),
+)
+```
+
+### Deprecated DTOs
+
+```php
+Dto::create('OldUser')->deprecated('Use User instead')->fields(...)
+```
+
+### Using Traits
+
+Add traits to generated DTO classes:
+
+```php
+Dto::create('User')->traits(\App\Dto\Traits\TimestampTrait::class)->fields(
+    Field::int('id')->required(),
+    Field::string('name'),
+)
+
+// Multiple traits
+Dto::create('Article')
+    ->traits(
+        \App\Dto\Traits\TimestampTrait::class,
+        \App\Dto\Traits\SoftDeleteTrait::class,
+    )
+    ->fields(...)
+```
+
+The traits must be fully qualified class names starting with `\`.
+
+## Complete Example
+
+```php
+<?php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\Field;
+use PhpCollective\Dto\Config\Schema;
+
+return Schema::create()
+    // Simple user DTO
+    ->dto(Dto::create('User')->fields(
+        Field::int('id')->required(),
+        Field::string('email')->required(),
+        Field::string('name')->required(),
+        Field::string('phone'),
+        Field::bool('active')->default(true),
+        Field::array('roles', 'string'),
+        Field::class('createdAt', \DateTimeImmutable::class),
+    ))
+
+    // Address DTO
+    ->dto(Dto::create('Address')->fields(
+        Field::string('street')->required(),
+        Field::string('city')->required(),
+        Field::string('country')->required(),
+        Field::string('zipCode'),
+    ))
+
+    // Order with nested DTOs and collection
+    ->dto(Dto::create('Order')->fields(
+        Field::int('id')->required(),
+        Field::dto('customer', 'User')->required(),
+        Field::dto('shippingAddress', 'Address')->required(),
+        Field::collection('items', 'OrderItem')->singular('item'),
+        Field::float('total')->required(),
+        Field::enum('status', \App\Enum\OrderStatus::class)->required(),
+    ))
+
+    // Order item with union type for flexible pricing
+    ->dto(Dto::create('OrderItem')->fields(
+        Field::union('productId', 'int', 'string')->required(),  // Flexible ID
+        Field::string('name')->required(),
+        Field::int('quantity')->required(),
+        Field::union('price', 'int', 'float')->required(),  // Price as int or float
+    ))
+
+    // Immutable event
+    ->dto(Dto::immutable('OrderPlaced')->fields(
+        Field::int('orderId')->required(),
+        Field::dto('order', 'Order')->required(),
+        Field::class('occurredAt', \DateTimeImmutable::class)->required(),
+    ))
+
+    // Extended DTO
+    ->dto(Dto::create('PremiumUser')->extends('User')->fields(
+        Field::string('membershipLevel')->required(),
+        Field::class('memberSince', \DateTimeImmutable::class),
+    ))
+
+    ->toArray();
+```
+
+## Mixing with Array Syntax
+
+The builder produces the same array format as manual configuration. You can mix both approaches:
+
+```php
+<?php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\Field;
+
+// Using builder for complex DTOs
+$schema = [
+    // Simple DTO using array syntax
+    'SimpleDto' => [
+        'fields' => [
+            'name' => 'string',
+            'count' => 'int',
+        ],
+    ],
+];
+
+// Add complex DTO using builder
+$complexDto = Dto::create('ComplexDto')->fields(
+    Field::int('id')->required(),
+    Field::collection('items', 'Item')->singular('item')->associative('slug'),
+);
+
+$schema[$complexDto->getName()] = $complexDto->toArray();
+
+return $schema;
+```
+
+## Output Format
+
+The builder generates the same array structure as manual configuration:
+
+```php
+// Builder
+Dto::create('User')->fields(
+    Field::int('id')->required(),
+    Field::string('email')->required(),
+    Field::bool('active')->default(true),
+)
+
+// Produces
+[
+    'fields' => [
+        'id' => ['type' => 'int', 'required' => true],
+        'email' => ['type' => 'string', 'required' => true],
+        'active' => ['type' => 'bool', 'defaultValue' => true],
+    ],
+]
+```
+
+Simple fields without modifiers are optimized to just the type string:
+
+```php
+Field::string('name')  // Produces: 'string' (not ['type' => 'string'])
+```
+
+## Validation Rules
+
+Fields support built-in validation rules that are checked when the DTO is constructed:
+
+```php
+Dto::create('User')->fields(
+    Field::string('name')->required()->minLength(2)->maxLength(100),
+    Field::string('email')->pattern('/^[^@]+@[^@]+\.[^@]+$/'),
+    Field::int('age')->min(0)->max(150),
+    Field::float('score')->min(0.0)->max(100.0),
+)
+```
+
+### Available Validation Methods
+
+| Method | Applies To | Description |
+|--------|-----------|-------------|
+| `minLength(int)` | string | Minimum string length (via `mb_strlen`) |
+| `maxLength(int)` | string | Maximum string length (via `mb_strlen`) |
+| `min(int\|float)` | int, float | Minimum numeric value |
+| `max(int\|float)` | int, float | Maximum numeric value |
+| `pattern(string)` | string | Regex pattern (must match via `preg_match`) |
+
+Null fields skip validation — rules are only checked when a value is present.
+
+On failure, an `InvalidArgumentException` is thrown with a descriptive message.
+
+## Lazy Properties
+
+DTO and collection fields can be marked as lazy, deferring hydration until first access:
+
+```php
+Dto::create('Order')->fields(
+    Field::int('id')->required(),
+    Field::dto('customer', 'Customer')->asLazy(),
+    Field::collection('items', 'OrderItem')->singular('item')->asLazy(),
+)
+```
+
+### How It Works
+
+Lazy fields store raw array data during construction in an internal `$_lazyData` property.
+When the getter is called for the first time, the raw data is hydrated into the DTO/collection
+and cached. Subsequent getter calls return the cached instance.
+
+```php
+$order = new OrderDto([
+    'id' => 1,
+    'customer' => ['name' => 'John', 'email' => 'john@example.com'],
+    'items' => [
+        ['product' => 'Widget', 'quantity' => 2],
+        ['product' => 'Gadget', 'quantity' => 1],
+    ],
+]);
+
+// No CustomerDto or OrderItemDto objects created yet
+
+$customer = $order->getCustomer();  // Now CustomerDto is hydrated
+$items = $order->getItems();        // Now OrderItemDto[] is hydrated
+```
+
+### toArray() Behavior
+
+If `toArray()` is called before the getter, the raw data is returned directly — no object
+creation occurs. This is useful for pass-through scenarios where DTOs are used for validation
+and transport without accessing nested fields:
+
+```php
+$order = new OrderDto($apiResponse);
+$json = json_encode($order->toArray());  // No nested DTOs created
+```
+
+### When to Use Lazy Properties
+
+- **Large nested structures** where not all fields are always accessed
+- **API pass-through** where data is validated and forwarded without deep inspection
+- **Performance-critical paths** where avoiding unnecessary object creation matters
+- **Deep object graphs** where eager hydration would create many unused objects
+
+### Mixing Lazy and Eager Fields
+
+You can mix lazy and eager fields in the same DTO:
+
+```php
+Dto::create('Order')->fields(
+    Field::int('id')->required(),
+    Field::string('status')->required(),           // Eager - always hydrated
+    Field::dto('customer', 'Customer')->asLazy(),  // Lazy - on-demand
+    Field::dto('summary', 'OrderSummary'),         // Eager - always hydrated
+    Field::collection('items', 'OrderItem')->singular('item')->asLazy(),  // Lazy
+)
+```
+
+## Readonly Properties
+
+DTOs can use PHP's `readonly` modifier for true immutability at the language level:
+
+```php
+Dto::create('Config')->readonlyProperties()->fields(
+    Field::string('host')->required(),
+    Field::int('port')->default(8080),
+)
+```
+
+This generates `public readonly` properties instead of `protected` ones, providing:
+
+- Direct public property access (`$dto->host` instead of `$dto->getHost()`)
+- Immutability enforcement (assignment after construction throws `\Error`)
+- Getters are still generated for consistency
+
+Note: `readonlyProperties()` implies `immutable` — the DTO will extend `AbstractImmutableDto`
+and use `with*()` methods (which reconstruct from array) instead of setters.
+
+### Usage Example
+
+```php
+$config = new ConfigDto(['host' => 'localhost', 'port' => 3306]);
+
+// Direct property access
+echo $config->host;  // "localhost"
+echo $config->port;  // 3306
+
+// Getters also work
+echo $config->getHost();  // "localhost"
+
+// Attempting to modify throws \Error at runtime
+$config->host = 'other';  // Error: Cannot modify readonly property
+
+// Use with*() methods to create modified copies
+$newConfig = $config->withPort(5432);
+echo $config->port;     // 3306 (original unchanged)
+echo $newConfig->port;  // 5432
+```
+
+### Readonly vs Immutable: When to Use Which
+
+| Feature | `immutable()` | `readonlyProperties()` |
+|---------|---------------|------------------------|
+| Property visibility | `protected` | `public readonly` |
+| Property access | `$dto->getName()` | `$dto->name` or `$dto->getName()` |
+| Modification protection | Convention (no setters) | Language-enforced |
+| `with*()` implementation | Clone + set property | Reconstruct from array |
+| API consistency | Same as mutable DTOs | Different from mutable DTOs |
+
+**Choose `immutable()`** when:
+- You want consistent getter-based API across all DTOs (mutable and immutable)
+- You're migrating between mutable and immutable and want minimal code changes
+
+**Choose `readonlyProperties()`** when:
+- You prefer shorter syntax with direct property access
+- You want IDE/static analysis to catch accidental mutation attempts

--- a/docs/guide/custom-casters.md
+++ b/docs/guide/custom-casters.md
@@ -1,0 +1,386 @@
+---
+title: Custom Casters / Transformers
+---
+
+# Custom Casters / Transformers
+
+This document explains how to customize value transformation when populating DTOs from arrays and when converting them back to arrays.
+
+## Overview
+
+DTOs support two transformation mechanisms:
+
+| Option | Direction | Purpose |
+|--------|-----------|---------|
+| `factory` | Array → Object | Create objects from raw values using a factory method |
+| `serialize` | Object → Array | Control how objects are converted in `toArray()` |
+| `transformFrom` / `transformTo` | Array → Value / Value → Array | Apply a callable before hydration or after serialization |
+
+## Factory - Creating Objects
+
+The `factory` option specifies a static method to call when creating an object from array data.
+
+### Basic Usage
+
+```php
+// config/dto.php (PHP Builder)
+Field::class('money', \Money\Money::class)->factory('fromArray')
+
+// The factory method is called like: Money::fromArray($value)
+```
+
+### Factory Formats
+
+**Method on the type class:**
+```
+factory: "fromArray"
+// Calls: TypeClass::fromArray($value)
+```
+
+**Method on a different class:**
+```
+factory: "App\Factory\MoneyFactory::create"
+// Calls: App\Factory\MoneyFactory::create($value)
+```
+
+### Configuration Examples
+
+#### PHP (Builder API)
+
+```php
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\Field;
+use PhpCollective\Dto\Config\Schema;
+
+return Schema::create()
+    ->dto(Dto::create('Order')->fields(
+        // Factory method on the type class
+        Field::class('money', \Money\Money::class)->factory('fromArray'),
+
+        // Factory method on a different class
+        Field::class('date', \DateTimeImmutable::class)
+            ->factory('DateTimeImmutable::createFromFormat'),
+
+        // Custom factory class
+        Field::class('price', \App\ValueObject\Price::class)
+            ->factory('App\Factory\PriceFactory::create'),
+    ))
+    ->toArray();
+```
+
+#### PHP (Array Syntax)
+
+```php
+return [
+    'Order' => [
+        'fields' => [
+            'money' => [
+                'type' => '\Money\Money',
+                'factory' => 'fromArray',
+            ],
+            'date' => [
+                'type' => '\DateTimeImmutable',
+                'factory' => 'DateTimeImmutable::createFromFormat',
+            ],
+        ],
+    ],
+];
+```
+
+#### XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="Order">
+        <field name="money" type="\Money\Money" factory="fromArray"/>
+        <field name="date" type="\DateTimeImmutable" factory="DateTimeImmutable::createFromFormat"/>
+        <field name="price" type="\App\ValueObject\Price" factory="App\Factory\PriceFactory::create"/>
+    </dto>
+</dtos>
+```
+
+#### YAML
+
+```yaml
+Order:
+  fields:
+    money:
+      type: '\Money\Money'
+      factory: fromArray
+    date:
+      type: '\DateTimeImmutable'
+      factory: 'DateTimeImmutable::createFromFormat'
+    price:
+      type: '\App\ValueObject\Price'
+      factory: 'App\Factory\PriceFactory::create'
+```
+
+#### NEON
+
+```neon
+Order:
+    fields:
+        money:
+            type: \Money\Money
+            factory: fromArray
+        date:
+            type: \DateTimeImmutable
+            factory: DateTimeImmutable::createFromFormat
+        price:
+            type: \App\ValueObject\Price
+            factory: App\Factory\PriceFactory::create
+```
+
+## Transforms - Pre/Post Processing
+
+Transforms apply a callable to a field value:
+
+```php
+Field::string('email')
+    ->transformFrom('App\\Transform\\Email::normalize')
+    ->transformTo('App\\Transform\\Email::mask');
+```
+
+Transforms run:
+- **Before hydration** (`transformFrom`) - after key mapping, before factories/DTO creation.
+- **After serialization** (`transformTo`) - after `toArray()`/collection conversion, before key mapping.
+
+Order of operations:
+
+1. `mapFrom` (input key mapping)
+2. `transformFrom`
+3. `factory` / DTO creation / enum handling
+4. `serialize` / DTO `toArray()`
+5. `transformTo`
+6. `mapTo` (output key mapping)
+
+For collections, transforms are applied to each element.
+
+## Choosing the Right Option
+
+| Use Case | Recommended |
+|----------|-------------|
+| Create a class instance from raw input | `factory` |
+| Convert an object to array/string on output | `serialize` |
+| Pre/post-process a scalar or array value | `transformFrom` / `transformTo` |
+
+## Serialize - Converting to Array
+
+The `serialize` option controls how objects are converted when calling `toArray()` on the DTO.
+
+### Serialization Modes
+
+| Mode | Method Called | Use Case |
+|------|---------------|----------|
+| `array` | `->toArray()` | Object has a toArray() method |
+| `string` | `->__toString()` | Object implements Stringable |
+| `FromArrayToArray` | `->toArray()` + `::fromArray()` | Full round-trip support |
+
+### Auto-Detection
+
+The library automatically detects serialization mode for classes that:
+- Implement `FromArrayToArrayInterface` → uses `FromArrayToArray`
+- Implement `JsonSerializable` → no transformation (JSON-safe)
+- Have a `toArray()` method → uses `array`
+
+You only need to specify `serialize` when you want to override the auto-detected behavior.
+
+### Configuration Examples
+
+#### PHP (Builder API)
+
+```php
+return Schema::create()
+    ->dto(Dto::create('Product')->fields(
+        // Serialize to array using toArray()
+        Field::class('dimensions', \App\ValueObject\Dimensions::class)
+            ->serialize('array'),
+
+        // Serialize to string using __toString()
+        Field::class('sku', \App\ValueObject\Sku::class)
+            ->serialize('string'),
+
+        // Full round-trip with FromArrayToArrayInterface
+        Field::class('metadata', \App\ValueObject\Metadata::class)
+            ->serialize('FromArrayToArray'),
+    ))
+    ->toArray();
+```
+
+#### PHP (Array Syntax)
+
+```php
+return [
+    'Product' => [
+        'fields' => [
+            'dimensions' => [
+                'type' => '\App\ValueObject\Dimensions',
+                'serialize' => 'array',
+            ],
+            'sku' => [
+                'type' => '\App\ValueObject\Sku',
+                'serialize' => 'string',
+            ],
+        ],
+    ],
+];
+```
+
+#### XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="php-collective-dto">
+    <dto name="Product">
+        <!-- Note: serialize is not in XSD yet, use array config for this -->
+        <field name="dimensions" type="\App\ValueObject\Dimensions"/>
+    </dto>
+</dtos>
+```
+
+#### YAML
+
+```yaml
+Product:
+  fields:
+    dimensions:
+      type: '\App\ValueObject\Dimensions'
+      serialize: array
+    sku:
+      type: '\App\ValueObject\Sku'
+      serialize: string
+```
+
+#### NEON
+
+```neon
+Product:
+    fields:
+        dimensions:
+            type: \App\ValueObject\Dimensions
+            serialize: array
+        sku:
+            type: \App\ValueObject\Sku
+            serialize: string
+```
+
+## Combining Factory and Serialize
+
+For full round-trip support, combine both options:
+
+```php
+Field::class('money', \App\ValueObject\Money::class)
+    ->factory('fromArray')
+    ->serialize('array')
+```
+
+This ensures:
+- **Input**: `Money::fromArray(['amount' => 100, 'currency' => 'USD'])` creates the object
+- **Output**: `$money->toArray()` converts it back to `['amount' => 100, 'currency' => 'USD']`
+
+## FromArrayToArrayInterface
+
+For the cleanest round-trip support, implement `FromArrayToArrayInterface`:
+
+```php
+use PhpCollective\Dto\Dto\FromArrayToArrayInterface;
+
+class Money implements FromArrayToArrayInterface
+{
+    public function __construct(
+        public readonly int $amount,
+        public readonly string $currency,
+    ) {}
+
+    public static function createFromArray(array $array): static
+    {
+        return new static($array['amount'], $array['currency']);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+        ];
+    }
+}
+```
+
+Classes implementing this interface are automatically detected - no need to specify `factory` or `serialize`:
+
+```php
+// Auto-detected as FromArrayToArray
+Field::class('money', \App\ValueObject\Money::class)
+```
+
+## Practical Examples
+
+### DateTimeImmutable with Custom Format
+
+```php
+// Value object wrapper for consistent date handling
+class EventDate
+{
+    private const FORMAT = 'Y-m-d H:i:s';
+
+    public function __construct(
+        private DateTimeImmutable $date,
+    ) {}
+
+    public static function fromString(string $value): self
+    {
+        return new self(new DateTimeImmutable($value));
+    }
+
+    public function __toString(): string
+    {
+        return $this->date->format(self::FORMAT);
+    }
+}
+
+// Configuration
+Field::class('eventDate', EventDate::class)
+    ->factory('fromString')
+    ->serialize('string')
+```
+
+### Money Value Object
+
+```php
+// Using a third-party money library
+Field::class('price', \Money\Money::class)
+    ->factory('Money\Parser::parse')
+
+// Or with custom wrapper
+Field::class('price', \App\Money::class)
+    ->factory('fromCents')
+    ->serialize('array')
+```
+
+### Enum-like Value Object
+
+```php
+class Status implements \Stringable
+{
+    private function __construct(
+        public readonly string $value,
+    ) {}
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}
+
+// Configuration
+Field::class('status', Status::class)
+    ->factory('fromString')
+    ->serialize('string')
+```

--- a/docs/guide/design-decisions.md
+++ b/docs/guide/design-decisions.md
@@ -1,0 +1,124 @@
+---
+title: Design Decisions
+---
+
+# Design Decisions
+
+## Non-Goals
+These features are intentionally out of scope:
+
+- ORM/Database integration - Keep library focused on data transfer
+- Request handling - Framework-specific, use adapters
+- Dependency injection - Use framework DI containers
+- Runtime reflection - Defeats purpose of code generation
+
+## Validation
+
+The library provides minimal built-in validation:
+- Required Fields
+- Type Checking
+
+For more complex validation, you can use a service like [Respect/Validation](https://respect-validation.readthedocs.io/en/latest/).
+
+We dont want to bloat the library with complex validation rules that are better handled by dedicated libraries.
+
+### Best Practices
+
+1. **Keep DTOs simple** - DTOs are data containers, not business logic holders. Consider using a separate validation service for complex rules.
+
+2. **Fail fast** - Use `required` for fields that must always be present. This catches errors at construction time.
+
+3. **Use type hints** - PHP's type system already validates types. A `string` field won't accept an integer.
+
+4. **Validate at boundaries** - Validate input at API/form boundaries, not deep in business logic.
+
+5. **Don't over-validate** - Internal DTOs used between trusted services don't need the same validation as user input DTOs.
+
+6. **Test validation** - Write unit tests for your validation rules.
+
+
+## Custom Casters / Transformers
+
+Current features are sufficient:
+```php
+// Input transformation
+->factory('fromArray')           // Calls ClassName::fromArray($value)
+->factory('fromString')          // Calls ClassName::fromString($value)
+->factory('External::create')    // Calls External::create($value)
+
+// Output transformation  
+->serialize('array')             // Calls $obj->toArray()
+->serialize('string')            // Calls $obj->__toString()
+->serialize('FromArrayToArray')  // Full round-trip
+```
+Plus auto-detection for:
+- FromArrayToArrayInterface
+- JsonSerializable
+- Enums (backed/unit)
+
+Additional casters add complexity without real benefit.
+
+## Readonly Properties (PHP 8.1+)
+
+- Generate truly readonly DTO properties.
+
+Low value for this library because:
+
+1. Breaks current patterns - fromArray(), setFromArray(), touched tracking don't work with readonly
+1. Already have immutable DTOs - with*() pattern works and is more flexible
+1. Public properties - Forces public visibility (debatable if good, we don't think so)
+
+Verdict: Nope. The current immutable DTO with with*() methods is more flexible for this use case.
+
+### Best Practices
+1. Use immutable DTOs for readonly behavior.
+2. Avoid mixing mutable and immutable DTOs.
+
+## Additional Serialization Formats (XML, CSV)
+Not at this point.
+
+Reason: Out of scope. Use symfony/serializer for complex serialization needs.
+
+## Advanced Type Constraints (positive-int, non-empty-string)
+Not at this point.
+
+Reason: Validation concern, not type concern. Use validation rules instead.
+
+
+## Computed Properties
+No need on the generated part.
+
+**Reason**: Use traits instead.
+```php
+// config
+Dto::create('User')->traits(\App\Traits\UserComputedTrait::class)->fields(...)
+
+// trait
+trait UserComputedTrait {
+    public function getFullName(): string {
+        return $this->firstName . ' ' . $this->lastName;
+    }
+}
+```
+
+## Lifecycle Hooks
+Not needed.
+
+**Reason**: Use traits instead.
+```php
+class UserDto extends AbstractUserDto {
+    protected function setFromArray(...): static {
+        // pre-processing
+        parent::setFromArray(...);
+        // post-processing
+        return $this;
+    }
+}
+```
+
+## Constructor promotion (PHP 8.0+)
+The real value of constructor promotion:
+- Reduces boilerplate in hand-written code
+- Our code is generated - verbosity isn't a maintenance burden
+
+Verdict: Not useful for this library. The flexibility of optional fields and incremental population is more valuable than the syntactic sugar of constructor promotion.

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -1,0 +1,809 @@
+---
+title: Examples
+---
+
+# Examples
+
+Practical examples demonstrating common DTO patterns and use cases.
+
+## Mutable DTOs
+
+Mutable DTOs allow direct modification. Changes affect all references to the same object.
+
+```php
+use App\Dto\CarDto;
+use App\Dto\OwnerDto;
+
+// Create and configure a mutable DTO
+$ownerDto = new OwnerDto();
+$ownerDto->setName('The Owner');
+
+$carDto = new CarDto();
+$carDto->setOwner($ownerDto);
+
+// References share the same object
+$otherCarDto = $carDto;
+$otherCarDto->getOwner()->setName('The new owner');
+
+// Both references see the change
+assert($carDto->getOwner()->getName() === 'The new owner');
+```
+
+This is the default behavior. If you need isolated copies, use immutable DTOs or explicit cloning.
+
+## Immutable DTOs
+
+Immutable DTOs create new instances for each modification, preserving the original.
+
+```xml
+<dto name="Article" immutable="true">
+    <field name="id" type="int" required="true"/>
+    <field name="title" type="string" required="true"/>
+    <field name="author" type="Author"/>
+    <field name="created" type="\DateTimeImmutable"/>
+</dto>
+```
+
+```php
+use App\Dto\ArticleDto;
+
+$array = [
+    'id' => 2,
+    'author' => ['id' => 1, 'name' => 'me'],
+    'title' => 'My title',
+    'created' => new DateTimeImmutable('-1 day'),
+];
+
+$articleDto = new ArticleDto($array);
+$modifiedArticleDto = $articleDto->withTitle('My new title');
+
+// Original remains unchanged
+assert($articleDto->getTitle() === 'My title');
+assert($modifiedArticleDto->getTitle() === 'My new title');
+```
+
+## Data Conversion Patterns
+
+### Entity to DTO
+
+Convert database entities or models to DTOs for safe transport across layers:
+
+```php
+// From any ORM/database layer
+$userData = $repository->findById(123);
+
+// Convert to DTO (array or object with toArray())
+$userDto = UserDto::createFromArray($userData->toArray());
+
+// Or pass array directly
+$userDto = UserDto::createFromArray([
+    'id' => $userData->id,
+    'email' => $userData->email,
+    'name' => $userData->name,
+]);
+```
+
+### DTO to Entity
+
+Convert DTOs back for persistence:
+
+```php
+// Get only the modified fields
+$changes = $userDto->touchedToArray();
+
+// Update entity with changes
+$entity->fill($changes);
+$repository->save($entity);
+```
+
+### Working with Relations
+
+```xml
+<dto name="Order">
+    <field name="id" type="int" required="true"/>
+    <field name="customer" type="Customer"/>
+    <field name="items" type="OrderItem[]" collection="true" singular="item"/>
+    <field name="createdAt" type="\DateTimeImmutable"/>
+</dto>
+```
+
+```php
+// Convert order with relations
+$orderData = $orderRepository->findWithRelations($orderId);
+
+// Deep conversion happens automatically
+$orderDto = OrderDto::createFromArray([
+    'id' => $orderData['id'],
+    'customer' => $orderData['customer'], // Converted to CustomerDto
+    'items' => $orderData['items'],       // Converted to OrderItemDto[]
+    'createdAt' => $orderData['created_at'],
+]);
+
+// Access nested data with type safety
+$customerName = $orderDto->getCustomer()->getName();
+
+foreach ($orderDto->getItems() as $item) {
+    echo $item->getProduct()->getName();
+}
+```
+
+## Key Format Handling
+
+### From Snake Case (Database/Forms)
+
+```php
+$formData = [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'email_address' => 'john@example.com',
+];
+
+$dto = new UserDto();
+$dto->fromArray($formData, false, UserDto::TYPE_UNDERSCORED);
+
+// Access with camelCase getters
+echo $dto->getFirstName();     // "John"
+echo $dto->getEmailAddress();  // "john@example.com"
+```
+
+### From Dash Case (URLs/APIs)
+
+```php
+$queryParams = [
+    'sort-by' => 'created_at',
+    'sort-order' => 'desc',
+    'page-size' => 25,
+];
+
+$dto = new PaginationDto();
+$dto->fromArray($queryParams, false, PaginationDto::TYPE_DASHED);
+
+echo $dto->getSortBy();    // "created_at"
+echo $dto->getPageSize();  // 25
+```
+
+### Export to Different Formats
+
+```php
+// Default camelCase
+$camelCase = $dto->toArray();
+// ['firstName' => 'John', 'lastName' => 'Doe']
+
+// Snake case for database
+$snakeCase = $dto->toArray(UserDto::TYPE_UNDERSCORED);
+// ['first_name' => 'John', 'last_name' => 'Doe']
+
+// Dash case for URLs
+$dashCase = $dto->toArray(UserDto::TYPE_DASHED);
+// ['first-name' => 'John', 'last-name' => 'Doe']
+```
+
+## Collections
+
+### Simple Collections
+
+```xml
+<dto name="Cart">
+    <field name="items" type="CartItem[]" collection="true" singular="item"/>
+</dto>
+```
+
+```php
+$cart = new CartDto();
+
+// Add items one by one
+$cart->addItem(new CartItemDto(['productId' => 1, 'quantity' => 2]));
+$cart->addItem(new CartItemDto(['productId' => 5, 'quantity' => 1]));
+
+// Check collection
+echo count($cart->getItems());  // 2
+
+// Iterate
+foreach ($cart->getItems() as $item) {
+    echo $item->getProductId() . ': ' . $item->getQuantity();
+}
+```
+
+### Associative Collections
+
+```xml
+<dto name="Config">
+    <field name="settings" type="Setting[]" collection="true"
+           singular="setting" associative="true"/>
+</dto>
+```
+
+```php
+$config = new ConfigDto();
+
+// Add with keys
+$config->addSetting('theme', new SettingDto(['value' => 'dark']));
+$config->addSetting('language', new SettingDto(['value' => 'en']));
+
+// Access by key
+$theme = $config->getSetting('theme');
+echo $theme->getValue();  // "dark"
+
+// Check existence
+if ($config->hasSetting('notifications')) {
+    // ...
+}
+```
+
+## Nested Reading
+
+Safe access to deeply nested values:
+
+```php
+$orderDto = OrderDto::createFromArray([
+    'customer' => [
+        'address' => [
+            'city' => 'New York',
+            'country' => 'USA',
+        ],
+    ],
+]);
+
+// Safe nested access
+$city = $orderDto->read(['customer', 'address', 'city']);
+// "New York"
+
+// With default for missing values
+$state = $orderDto->read(['customer', 'address', 'state'], 'Unknown');
+// "Unknown"
+
+// Returns null for missing paths (without default)
+$zipCode = $orderDto->read(['customer', 'address', 'zipCode']);
+// null
+```
+
+## Deep Cloning
+
+Create independent copies of nested structures:
+
+```php
+$original = new OrderDto();
+$original->setCustomer(new CustomerDto(['name' => 'John']));
+
+// Deep clone
+$clone = $original->clone();
+$clone->getCustomer()->setName('Jane');
+
+// Original is unchanged
+assert($original->getCustomer()->getName() === 'John');
+assert($clone->getCustomer()->getName() === 'Jane');
+```
+
+## Required Fields
+
+Ensure critical data is always present:
+
+```xml
+<dto name="User">
+    <field name="id" type="int" required="true"/>
+    <field name="email" type="string" required="true"/>
+    <field name="name" type="string"/>
+</dto>
+```
+
+```php
+// This throws an exception - required fields missing
+$user = new UserDto(['name' => 'John']);
+// RuntimeException: Required field 'id' is missing
+
+// Proper initialization
+$user = new UserDto([
+    'id' => 1,
+    'email' => 'john@example.com',
+    'name' => 'John',
+]);
+```
+
+## OrFail Methods
+
+Get values with guaranteed non-null returns:
+
+```php
+// Standard getter - may return null
+$email = $userDto->getEmail();  // string|null
+
+// OrFail getter - throws if null
+$email = $userDto->getEmailOrFail();  // string (throws if not set)
+```
+
+Useful when you know a value must exist:
+
+```php
+// After validation, we know email exists
+$validatedDto = $this->validateUser($inputDto);
+$email = $validatedDto->getEmailOrFail();  // Safe - validation ensures it exists
+```
+
+## Default Values
+
+Provide sensible defaults:
+
+```xml
+<dto name="Pagination">
+    <field name="page" type="int" defaultValue="1"/>
+    <field name="perPage" type="int" defaultValue="20"/>
+    <field name="sortOrder" type="string" defaultValue="asc"/>
+</dto>
+```
+
+```php
+$pagination = new PaginationDto();
+
+echo $pagination->getPage();      // 1
+echo $pagination->getPerPage();   // 20
+echo $pagination->getSortOrder(); // "asc"
+
+// Override defaults as needed
+$pagination->setPage(5);
+```
+
+## Custom Collection Types
+
+By default, DTO collections return `ArrayObject`. You can customize this globally to use your framework's collection class, gaining access to powerful collection methods like `filter()`, `map()`, `reduce()`, etc.
+
+### Why Use Custom Collections?
+
+`ArrayObject` is functional but limited. Framework collections provide:
+- Fluent, chainable operations (`->filter()->map()->sum()`)
+- Lazy evaluation (in some implementations)
+- Framework-specific integrations (e.g., Laravel's `pluck()`, CakePHP's `groupBy()`)
+
+### Setting a Global Factory
+
+Set the factory early in your application bootstrap, before any DTOs are instantiated:
+
+```php
+use PhpCollective\Dto\Dto\Dto;
+
+// CakePHP Collection
+Dto::setCollectionFactory(fn(array $items) => new \Cake\Collection\Collection($items));
+
+// Laravel Collection
+Dto::setCollectionFactory(fn(array $items) => collect($items));
+
+// Doctrine ArrayCollection
+Dto::setCollectionFactory(fn(array $items) => new \Doctrine\Common\Collections\ArrayCollection($items));
+```
+
+### Using Framework Collection Methods
+
+Once set, all DTO collections gain the framework's collection methods:
+
+```php
+// With Laravel collection factory
+Dto::setCollectionFactory(fn($items) => collect($items));
+
+$cart = new CartDto();
+// ... add items
+
+// Use Laravel collection methods
+$total = $cart->getItems()
+    ->filter(fn($item) => $item->getQuantity() > 0)
+    ->sum(fn($item) => $item->getPrice() * $item->getQuantity());
+
+$productNames = $cart->getItems()
+    ->pluck('name')
+    ->unique()
+    ->values();
+```
+
+### Resetting to Default
+
+```php
+// Reset to default ArrayObject
+Dto::setCollectionFactory(null);
+```
+
+### When to Use
+
+- **API applications**: Laravel/Symfony collections for response transformation
+- **Domain logic**: Filter, aggregate, transform collections fluently
+- **Testing**: Reset factory between tests to avoid state pollution
+
+## API Response Pattern
+
+```php
+class UserController
+{
+    public function show(int $id): array
+    {
+        $user = $this->userRepository->find($id);
+
+        $dto = UserDto::createFromArray([
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'createdAt' => $user->created_at,
+        ]);
+
+        // Return as snake_case for JSON API
+        return $dto->toArray(UserDto::TYPE_UNDERSCORED);
+    }
+}
+```
+
+## Form Handling Pattern
+
+```php
+public function update(Request $request, int $id): Response
+{
+    // Convert form input to DTO
+    $dto = new UserDto();
+    $dto->fromArray($request->all(), false, UserDto::TYPE_UNDERSCORED);
+
+    // Validate and process
+    $this->validator->validate($dto);
+
+    // Get only changed fields for partial update
+    $changes = $dto->touchedToArray();
+
+    $this->userRepository->update($id, $changes);
+
+    return new Response('Updated');
+}
+```
+
+## Value Object Integration
+
+DTOs work seamlessly with value objects:
+
+```xml
+<dto name="Product">
+    <field name="id" type="int"/>
+    <field name="name" type="string"/>
+    <field name="price" type="\Money\Money"/>
+    <field name="createdAt" type="\DateTimeImmutable"/>
+</dto>
+```
+
+```php
+use Money\Money;
+use Money\Currency;
+
+$product = new ProductDto([
+    'id' => 1,
+    'name' => 'Widget',
+    'price' => Money::of(1999, new Currency('USD')),
+    'createdAt' => new DateTimeImmutable(),
+]);
+
+$price = $product->getPrice();
+echo $price->getAmount();  // 1999
+```
+
+## Enum Support
+
+```xml
+<dto name="Order">
+    <field name="status" type="\App\Enum\OrderStatus"/>
+</dto>
+```
+
+```php
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Confirmed = 'confirmed';
+    case Shipped = 'shipped';
+    case Delivered = 'delivered';
+}
+
+$order = new OrderDto([
+    'status' => OrderStatus::Pending,
+]);
+
+// Or from string value
+$order = new OrderDto([
+    'status' => 'confirmed',  // Automatically converted to enum
+]);
+
+$status = $order->getStatus();  // OrderStatus::Confirmed
+```
+
+## Deprecation Handling
+
+Mark fields as deprecated for gradual migration:
+
+```xml
+<dto name="User">
+    <field name="username" type="string" deprecated="Use email instead"/>
+    <field name="email" type="string"/>
+</dto>
+```
+
+Your IDE will show deprecation warnings when using `getUsername()` or `setUsername()`.
+
+## JSON Serialization
+
+### To JSON
+
+```php
+$dto = new UserDto(['name' => 'John', 'email' => 'john@example.com']);
+
+// Using serialize() - returns JSON string of touched fields
+$json = $dto->serialize();
+// {"name":"John","email":"john@example.com"}
+
+// Using toArray() with json_encode - all fields
+$json = json_encode($dto->toArray());
+
+// Pretty printed
+$json = json_encode($dto->toArray(), JSON_PRETTY_PRINT);
+
+// With key format conversion
+$json = json_encode($dto->toArray(UserDto::TYPE_UNDERSCORED));
+// {"name":"John","email":"john@example.com"}
+```
+
+### From JSON
+
+```php
+// Using fromUnserialized() - static constructor
+$json = '{"name":"John","email":"john@example.com"}';
+$dto = UserDto::fromUnserialized($json);
+
+// Using json_decode + constructor
+$data = json_decode($json, true);
+$dto = new UserDto($data);
+
+// With ignoreMissing for partial JSON
+$partialJson = '{"name":"John"}';
+$dto = new UserDto(json_decode($partialJson, true), ignoreMissing: true);
+```
+
+### API Response Pattern
+
+```php
+class ApiController
+{
+    public function show(int $id): JsonResponse
+    {
+        $user = $this->userRepository->find($id);
+        $dto = UserDto::createFromArray($user->toArray());
+
+        return new JsonResponse($dto->toArray(UserDto::TYPE_UNDERSCORED));
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $dto = new UserDto(
+            $request->json()->all(),
+            ignoreMissing: true,
+        );
+
+        $user = $this->userService->create($dto);
+
+        return new JsonResponse(
+            UserDto::createFromArray($user->toArray())->toArray(),
+            201,
+        );
+    }
+}
+```
+
+### Debugging with JSON
+
+```php
+// Quick debug output
+echo json_encode($dto->toArray(), JSON_PRETTY_PRINT);
+
+// Or use __toString which returns JSON
+echo $dto;  // Calls serialize() internally
+```
+
+## Validation Rules
+
+Built-in validation rules provide field-level constraints checked during construction.
+
+### Basic Validation
+
+```php
+// Configuration
+Dto::create('User')->fields(
+    Field::string('username')->required()->minLength(3)->maxLength(20),
+    Field::string('email')->required()->pattern('/^[^@]+@[^@]+\.[^@]+$/'),
+    Field::int('age')->min(0)->max(150),
+)
+```
+
+```php
+// Valid - passes all rules
+$user = new UserDto([
+    'username' => 'johndoe',
+    'email' => 'john@example.com',
+    'age' => 25,
+]);
+
+// Invalid - throws InvalidArgumentException
+$user = new UserDto([
+    'username' => 'jo',  // Too short (minLength: 3)
+    'email' => 'john@example.com',
+]);
+// Exception: Field 'username' must be at least 3 characters
+
+// Invalid email pattern
+$user = new UserDto([
+    'username' => 'johndoe',
+    'email' => 'not-an-email',
+]);
+// Exception: Field 'email' does not match required pattern
+```
+
+### Nullable Fields Skip Validation
+
+```php
+Dto::create('Profile')->fields(
+    Field::string('bio')->maxLength(500),  // Optional field
+    Field::int('followers')->min(0),
+)
+```
+
+```php
+// Null values skip validation
+$profile = new ProfileDto(['bio' => null, 'followers' => null]);  // OK
+
+// Non-null values are validated
+$profile = new ProfileDto(['bio' => str_repeat('x', 501)]);
+// Exception: Field 'bio' must be at most 500 characters
+```
+
+### Extracting Validation Rules
+
+Use `validationRules()` to get framework-agnostic rules for integration with validators:
+
+```php
+$dto = new UserDto(['username' => 'test', 'email' => 'test@example.com']);
+$rules = $dto->validationRules();
+
+// Returns:
+// [
+//     'username' => ['required' => true, 'minLength' => 3, 'maxLength' => 20],
+//     'email' => ['required' => true, 'pattern' => '/^[^@]+@[^@]+\.[^@]+$/'],
+//     'age' => ['min' => 0, 'max' => 150],
+// ]
+
+// Use with framework validators
+$validator = new FrameworkValidator($rules);
+```
+
+## Lazy Loading
+
+Defer nested DTO/collection hydration for performance optimization.
+
+### Basic Lazy Loading
+
+```php
+// Configuration
+Dto::create('Order')->fields(
+    Field::int('id')->required(),
+    Field::string('status'),
+    Field::dto('customer', 'Customer')->asLazy(),
+    Field::collection('items', 'OrderItem')->singular('item')->asLazy(),
+)
+```
+
+```php
+// Create order from API response
+$order = new OrderDto([
+    'id' => 123,
+    'status' => 'pending',
+    'customer' => ['name' => 'John', 'email' => 'john@example.com'],
+    'items' => [
+        ['product' => 'Widget', 'quantity' => 2, 'price' => 29.99],
+        ['product' => 'Gadget', 'quantity' => 1, 'price' => 49.99],
+    ],
+]);
+
+// At this point: no CustomerDto or OrderItemDto objects exist yet
+
+// Access triggers hydration
+$customer = $order->getCustomer();  // CustomerDto created now
+echo $customer->getName();  // "John"
+```
+
+### Pass-Through Optimization
+
+When data is forwarded without deep inspection, lazy fields avoid unnecessary object creation:
+
+```php
+// API gateway scenario
+$orderData = $this->fetchFromUpstreamApi();
+$order = new OrderDto($orderData);
+
+// Forward to downstream service - no nested objects created
+$this->downstreamApi->send($order->toArray());
+```
+
+### Checking Lazy State
+
+```php
+// Access triggers hydration - subsequent calls return cached instance
+$items1 = $order->getItems();  // Hydrated
+$items2 = $order->getItems();  // Same instance returned
+assert($items1 === $items2);
+```
+
+## Readonly Properties
+
+Use `readonly` properties for language-level immutability with direct property access.
+
+### Basic Readonly DTO
+
+```php
+// Configuration
+Dto::create('DatabaseConfig')->readonlyProperties()->fields(
+    Field::string('host')->required(),
+    Field::int('port')->default(3306),
+    Field::string('database')->required(),
+    Field::string('username')->required(),
+    Field::string('password'),
+)
+```
+
+```php
+$config = new DatabaseConfigDto([
+    'host' => 'localhost',
+    'database' => 'myapp',
+    'username' => 'root',
+]);
+
+// Direct property access
+echo $config->host;      // "localhost"
+echo $config->port;      // 3306 (default)
+echo $config->database;  // "myapp"
+
+// Getters also work
+echo $config->getHost();  // "localhost"
+
+// Modification throws Error
+$config->host = 'other';  // Error: Cannot modify readonly property
+```
+
+### Creating Modified Copies
+
+```php
+$devConfig = new DatabaseConfigDto([
+    'host' => 'localhost',
+    'database' => 'myapp_dev',
+    'username' => 'dev',
+]);
+
+// Create production config based on dev
+$prodConfig = $devConfig
+    ->withHost('prod-db.example.com')
+    ->withDatabase('myapp_prod')
+    ->withUsername('app_user')
+    ->withPassword('secret');
+
+// Original unchanged
+echo $devConfig->host;   // "localhost"
+echo $prodConfig->host;  // "prod-db.example.com"
+```
+
+### Readonly vs Immutable Comparison
+
+```php
+// Immutable DTO - getter-based access (consistent with mutable DTOs)
+Dto::immutable('Event')->fields(
+    Field::string('name')->required(),
+    Field::string('payload'),
+)
+
+$event = new EventDto(['name' => 'user.created', 'payload' => '{}']);
+echo $event->getName();     // Access via getter
+
+// Readonly DTO - direct property access
+Dto::create('Event')->readonlyProperties()->fields(
+    Field::string('name')->required(),
+    Field::string('payload'),
+)
+
+$event = new EventDto(['name' => 'user.created', 'payload' => '{}']);
+echo $event->name;          // Direct access - shorter syntax
+echo $event->getName();     // Getter also works
+```

--- a/docs/guide/framework-integration.md
+++ b/docs/guide/framework-integration.md
@@ -1,0 +1,634 @@
+---
+title: Framework Integration
+---
+
+# Framework Integration
+
+This library is **framework-agnostic** by design. It works with any PHP framework without requiring wrapper packages, while still offering deep integration possibilities.
+
+Do We Need Wrapper Libraries?
+
+| Feature            | Without Wrapper    | With Wrapper                |
+  |--------------------|--------------------|-----------------------------|
+| Basic usage        | ✅ Works           | ✅ Works                    |
+| Collection factory | 1 line setup       | Auto-configured             |
+| Code generation    | bin/dto generate   | artisan dto:generate        |
+| Request → DTO      | Manual             | Auto via injection          |
+| Validation         | Manual integration | Native framework validators |
+| IDE support        | ✅ Full            | ✅ Full                     |
+
+## Quick Setup
+
+### Laravel
+
+```php
+// app/Providers/AppServiceProvider.php
+use PhpCollective\Dto\Dto\Dto;
+
+public function boot(): void
+{
+    // Enable Laravel collections for DTO collection fields
+    Dto::setCollectionFactory(fn (array $items) => collect($items));
+}
+```
+
+### Symfony
+
+```php
+// src/Kernel.php or an event listener
+use PhpCollective\Dto\Dto\Dto;
+
+// In boot or kernel.request listener
+Dto::setCollectionFactory(fn (array $items) => new ArrayCollection($items));
+```
+
+### CakePHP
+
+```php
+// config/bootstrap.php or Application.php
+use PhpCollective\Dto\Dto\Dto;
+use Cake\Collection\Collection;
+
+Dto::setCollectionFactory(fn (array $items) => new Collection($items));
+```
+
+### CakePHP projectAs() and Special Fields
+
+CakePHP 5.3+ introduces `projectAs()` for projecting ORM results directly into DTOs. Some CakePHP features use underscore-prefixed field names:
+
+- `_joinData` - BelongsToMany pivot table data
+- `_matchingData` - Data from `matching()` queries
+
+These field names are fully supported:
+
+```xml
+<!-- config/dto.xml -->
+<dto name="Tag" immutable="true">
+    <field name="id" type="int"/>
+    <field name="name" type="string"/>
+    <field name="_joinData" type="Tagged"/>
+</dto>
+
+<dto name="UserWithMatching" immutable="true">
+    <field name="id" type="int"/>
+    <field name="username" type="string"/>
+    <field name="_matchingData" type="MatchingData"/>
+</dto>
+```
+
+The generated methods use proper camelCase (the leading underscore is stripped for method/constant names):
+
+```php
+// Field: _joinData
+$tag->getJoinData();      // getter
+$tag->withJoinData($data); // immutable setter
+TagDto::FIELD_JOIN_DATA;   // constant
+
+// Field: _matchingData
+$user->getMatchingData();
+$user->withMatchingData($data);
+UserWithMatchingDto::FIELD_MATCHING_DATA;
+```
+
+Usage with CakePHP's projectAs():
+
+```php
+// BelongsToMany with _joinData
+$posts = $postsTable->find()
+    ->contain(['Tags'])
+    ->projectAs(PostDto::class)
+    ->toArray();
+
+foreach ($posts as $post) {
+    foreach ($post->getTags() as $tag) {
+        $pivotData = $tag->getJoinData(); // Access pivot table data
+    }
+}
+
+// Matching query with _matchingData
+$users = $usersTable->find()
+    ->matching('Roles', fn ($q) => $q->where(['Roles.id' => 1]))
+    ->projectAs(UserWithMatchingDto::class)
+    ->toArray();
+
+foreach ($users as $user) {
+    $matchingRoles = $user->getMatchingData(); // Access matched association data
+}
+```
+
+## Controller Usage
+
+### Laravel
+
+```php
+use App\Dto\UserDto;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        // From validated request
+        $dto = new UserDto($request->validated());
+
+        // Or with ignoreMissing for partial updates
+        $dto = UserDto::createFromArray($request->all(), ignoreMissing: true);
+
+        // Use Laravel collection methods on DTO collections
+        $activeUsers = $dto->getRoles()->filter(fn ($role) => $role->isActive());
+
+        return response()->json($dto->toArray());
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $user = User::findOrFail($id);
+        $dto = new UserDto($user->toArray());
+
+        return response()->json($dto);
+    }
+}
+```
+
+### Symfony
+
+```php
+use App\Dto\UserDto;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class UserController extends AbstractController
+{
+    #[Route('/users', methods: ['POST'])]
+    public function store(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $dto = new UserDto($data);
+
+        return $this->json($dto->toArray());
+    }
+}
+```
+
+### CakePHP
+
+```php
+use App\Dto\UserDto;
+
+class UsersController extends AppController
+{
+    public function add()
+    {
+        if ($this->request->is('post')) {
+            $dto = new UserDto($this->request->getData());
+
+            // Use CakePHP collection methods
+            $items = $dto->getItems()->filter(fn ($item) => $item->getQuantity() > 0);
+
+            // ... save logic
+        }
+    }
+}
+```
+
+## Validation
+
+The library doesn't include validation - use your framework's validator.
+
+### Laravel
+
+```php
+use Illuminate\Support\Facades\Validator;
+
+$dto = new UserDto($request->all(), ignoreMissing: true);
+
+$validator = Validator::make($dto->toArray(), [
+    'name' => 'required|string|max:255',
+    'email' => 'required|email|unique:users',
+]);
+
+if ($validator->fails()) {
+    return response()->json(['errors' => $validator->errors()], 422);
+}
+```
+
+### Symfony
+
+```php
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class UserController extends AbstractController
+{
+    public function store(Request $request, ValidatorInterface $validator): JsonResponse
+    {
+        $dto = new UserDto(json_decode($request->getContent(), true));
+
+        // Validate the DTO array representation
+        $violations = $validator->validate($dto->toArray(), new Assert\Collection([
+            'name' => [new Assert\NotBlank(), new Assert\Length(['max' => 255])],
+            'email' => [new Assert\NotBlank(), new Assert\Email()],
+        ]));
+
+        if (count($violations) > 0) {
+            return $this->json(['errors' => (string) $violations], 422);
+        }
+
+        return $this->json($dto->toArray());
+    }
+}
+```
+
+See [Validation](./validation) for more validation patterns.
+
+## Code Generation
+
+The CLI tool works the same way in any framework:
+
+```bash
+# Generate DTOs from config
+bin/dto generate config/dto.php src/Dto App\\Dto
+
+# Or with XML
+bin/dto generate config/dto.xml src/Dto App\\Dto
+```
+
+### Framework-Specific Paths
+
+| Framework | Config Path | Output Path | Namespace |
+|-----------|-------------|-------------|-----------|
+| Laravel | `config/dto.php` | `app/Dto` | `App\Dto` |
+| Symfony | `config/dto.xml` | `src/Dto` | `App\Dto` |
+| CakePHP | `config/dto.php` | `src/Dto` | `App\Dto` |
+
+### Composer Scripts
+
+Add to your `composer.json` for convenience:
+
+```json
+{
+    "scripts": {
+        "dto:generate": "bin/dto generate config/dto.php src/Dto App\\Dto"
+    }
+}
+```
+
+Then run: `composer dto:generate`
+
+## What Wrapper Packages Could Add
+
+While not required, framework-specific packages could provide:
+
+### Potential Laravel Package Features
+
+| Feature | Current (Manual) | With Package |
+|---------|------------------|--------------|
+| Collection factory | 1 line in ServiceProvider | Auto-configured |
+| Request → DTO | `new UserDto($request->validated())` | `UserDto::fromRequest($request)` |
+| Route binding | Manual | `Route::dto(UserDto::class)` |
+| Artisan command | `bin/dto generate` | `php artisan dto:generate` |
+| Config publishing | Manual | `php artisan vendor:publish` |
+
+```php
+// Hypothetical Laravel package usage
+public function store(UserDto $dto): JsonResponse  // Auto-injected from request
+{
+    return response()->json($dto);
+}
+```
+
+### Potential Symfony Bundle Features
+
+| Feature | Current (Manual) | With Bundle |
+|---------|------------------|-------------|
+| Collection factory | Kernel listener | Auto-configured |
+| Request → DTO | Manual JSON decode | ParamConverter |
+| Console command | `bin/dto generate` | `bin/console dto:generate` |
+| Autowiring | Manual | Service definitions |
+
+```php
+// Hypothetical Symfony bundle usage
+#[Route('/users', methods: ['POST'])]
+public function store(#[MapRequestPayload] UserDto $dto): JsonResponse
+{
+    return $this->json($dto);
+}
+```
+
+## Comparison With Other Libraries
+
+| Library | Framework Integration |
+|---------|----------------------|
+| **php-collective/dto** | Framework-agnostic, optional adapters |
+| spatie/laravel-data | Laravel-only, deep integration |
+| cuyz/valinor | Framework-agnostic + optional Symfony bundle |
+| symfony/serializer | Symfony-native, usable standalone |
+
+### Philosophy
+
+This library follows the approach of [cuyz/valinor](https://github.com/CuyZ/Valinor) and similar tools:
+
+1. **Core library** - Works everywhere, no dependencies
+2. **Optional adapters** - Framework-specific convenience packages
+3. **No lock-in** - Switch frameworks without changing DTOs
+
+## Input Transformation
+
+Unlike spatie/laravel-data which has built-in [Casts](https://spatie.be/docs/laravel-data/v4/as-a-data-transfer-object/casts) and [Transformers](https://spatie.be/docs/laravel-data/v4/as-a-resource/transformers), this library keeps transformation simple:
+
+### Recommended Patterns
+
+**Pre-process data before DTO creation:**
+
+```php
+// Sanitize input
+$data = $request->validated();
+$data['name'] = trim($data['name'] ?? '');
+$data['email'] = strtolower($data['email'] ?? '');
+
+$dto = new UserDto($data);
+```
+
+**Use a static factory method:**
+
+```php
+class UserDto extends AbstractDto
+{
+    public static function fromRequest(Request $request): static
+    {
+        $data = $request->validated();
+
+        // Transform as needed
+        $data['name'] = trim($data['name'] ?? '');
+
+        return new static($data);
+    }
+}
+```
+
+**Use the `factory` config option for objects:**
+
+```php
+// config/dto.php
+'Payment' => [
+    'fields' => [
+        'amount' => [
+            'type' => '\Money\Money',
+            'factory' => 'Money\Parser::parse',
+        ],
+    ],
+],
+```
+
+### Why No Built-in Transformers?
+
+1. **Performance** - Runtime callbacks slow down the optimized `setFromArrayFast` path
+2. **Simplicity** - Code generation produces simple, debuggable code
+3. **Flexibility** - Pre-processing works with any transformation library
+4. **Framework choice** - Use Laravel's mutators, Symfony's normalizers, or plain PHP
+
+## Service Container Integration
+
+### Laravel
+
+```php
+// app/Providers/AppServiceProvider.php
+public function register(): void
+{
+    $this->app->bind(OrderDto::class, function ($app, $params) {
+        return new OrderDto($params['data'] ?? []);
+    });
+}
+```
+
+### Symfony
+
+```yaml
+# config/services.yaml
+services:
+    App\Dto\OrderDto:
+        autoconfigure: false
+        autowire: false
+```
+
+DTOs are typically instantiated directly rather than through the container, as they're data holders, not services.
+
+## Doctrine ORM Integration
+
+Generated DTOs work well with Doctrine for read-optimized queries.
+
+### Partial Select + DTO Hydration
+
+The recommended approach: fetch only needed fields as arrays, then hydrate DTOs:
+
+```php
+use App\Dto\UserSummaryDto;
+
+// Fetch partial data as array (fast - no entity hydration)
+$rows = $entityManager->createQuery(
+    'SELECT u.id, u.name, u.email
+     FROM App\Entity\User u
+     WHERE u.active = true'
+)->getArrayResult();
+
+// Hydrate generated DTOs
+$users = array_map(fn($row) => new UserSummaryDto($row), $rows);
+
+// All generated methods available
+foreach ($users as $user) {
+    echo $user->getName();
+    echo $user->getEmail();
+}
+```
+
+### Why Not SELECT NEW?
+
+Doctrine's `SELECT NEW` passes **positional arguments**:
+```php
+SELECT NEW App\Dto\UserDto(u.id, u.name, u.email)
+// Calls: new UserDto($id, $name, $email)
+```
+
+Generated DTOs expect an **array**:
+```php
+new UserDto(['id' => 1, 'name' => 'John', 'email' => 'john@example.com'])
+```
+
+Using `getArrayResult()` + DTO hydration gives the same performance benefits while working with generated DTOs.
+
+However, if you prefer Doctrine's native `SELECT NEW` syntax, you can use **mapper classes**.
+
+### Doctrine SELECT NEW with Mappers
+
+Generate mapper classes alongside your DTOs:
+
+```bash
+vendor/bin/dto generate --mapper
+```
+
+This creates mapper classes that extend DTOs with positional constructors:
+
+```
+src/Dto/
+├── UserSummaryDto.php           # Standard DTO (array constructor)
+└── Mapper/
+    └── UserSummaryDtoMapper.php # Mapper (positional constructor)
+```
+
+**Generated Mapper Structure:**
+
+```php
+namespace App\Dto\Mapper;
+
+use App\Dto\UserSummaryDto;
+
+class UserSummaryDtoMapper extends UserSummaryDto
+{
+    public function __construct(
+        int $id,
+        string $name,
+        ?string $email
+    ) {
+        parent::__construct([
+            'id' => $id,
+            'name' => $name,
+            'email' => $email,
+        ]);
+    }
+}
+```
+
+**Usage with Doctrine:**
+
+```php
+use App\Dto\Mapper\UserSummaryDtoMapper;
+
+// Use the mapper in SELECT NEW
+$users = $entityManager->createQuery(
+    'SELECT NEW App\Dto\Mapper\UserSummaryDtoMapper(u.id, u.name, u.email)
+     FROM App\Entity\User u
+     WHERE u.active = true'
+)->getResult();
+
+// Results are fully-functional DTOs
+foreach ($users as $user) {
+    echo $user->getName();    // All getter methods work
+    echo $user->toArray();    // Serialization works
+}
+
+// Type hints work - mapper IS-A DTO
+function processUser(UserSummaryDto $dto): void { /* ... */ }
+processUser($users[0]);  // Works because UserSummaryDtoMapper extends UserSummaryDto
+```
+
+**Benefits of Mappers:**
+
+| Feature | getArrayResult + DTO | SELECT NEW + Mapper |
+|---------|---------------------|---------------------|
+| Performance | ✅ Fast | ✅ Fast |
+| Type safety | ✅ Full | ✅ Full |
+| Code style | Manual mapping | Native DQL |
+| Single query | ✅ Yes | ✅ Yes |
+| IDE support | ✅ Full | ✅ Full |
+
+Both approaches produce identical results. Choose based on preference:
+- **getArrayResult**: More explicit, works with any DTO
+- **SELECT NEW + Mapper**: Native DQL syntax, requires `--mapper` flag
+
+### DTO Definition for Query Results
+
+Define lightweight DTOs for specific queries:
+
+```php
+// config/dto.php
+return Schema::create()
+    ->dto(Dto::create('UserSummary')->fields(
+        Field::int('id'),
+        Field::string('name'),
+        Field::string('email'),
+    ))
+    ->toArray();
+```
+
+### With Query Builder
+
+```php
+$qb = $entityManager->createQueryBuilder();
+$rows = $qb->select('o.id', 'o.total', 'c.name AS customerName')
+   ->from(Order::class, 'o')
+   ->join('o.customer', 'c')
+   ->where('o.status = :status')
+   ->setParameter('status', 'completed')
+   ->getQuery()
+   ->getArrayResult();
+
+$orders = array_map(fn($row) => new OrderSummaryDto($row), $rows);
+```
+
+### Repository Pattern
+
+```php
+class UserRepository extends ServiceEntityRepository
+{
+    /**
+     * @return UserSummaryDto[]
+     */
+    public function findActiveSummaries(): array
+    {
+        $rows = $this->createQueryBuilder('u')
+            ->select('u.id', 'u.name', 'u.email')
+            ->where('u.active = true')
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(fn($row) => new UserSummaryDto($row), $rows);
+    }
+}
+```
+
+### Entity to DTO Conversion
+
+For converting full entities to DTOs:
+
+```php
+// Simple conversion
+$user = $entityManager->find(User::class, 1);
+$dto = new UserDto($user->toArray());
+
+// Or with a static factory
+class UserDto extends AbstractDto
+{
+    public static function fromEntity(User $user): static
+    {
+        return new static([
+            'id' => $user->getId(),
+            'name' => $user->getName(),
+            'email' => $user->getEmail(),
+            'roles' => $user->getRoles()->map(fn ($r) => [
+                'id' => $r->getId(),
+                'name' => $r->getName(),
+            ])->toArray(),
+        ]);
+    }
+}
+```
+
+### Why Use DTOs with Doctrine?
+
+| Approach | Use Case |
+|----------|----------|
+| **Entity directly** | Internal domain logic, persistence |
+| **DTO via getArrayResult** | Simple queries, manual mapping |
+| **DTO via SELECT NEW + Mapper** | Native DQL syntax, type-safe results |
+| **DTO from Entity** | When you need the full entity first, then transform |
+
+Benefits of DTOs for query results:
+- **Performance**: Only hydrate needed fields, no proxy objects
+- **API safety**: No lazy-loading surprises in JSON responses
+- **Clear contracts**: DTOs define exactly what the API returns
+- **Immutability**: Use immutable DTOs for read-only data
+
+## Further Reading
+
+- [Custom Collection Types](./examples#custom-collection-types)
+- [Validation](./validation)
+- [Migration Guide](./migration)

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,276 @@
+---
+title: Getting Started
+description: Quick start guide for PHP DTO with code generation
+---
+
+# Getting Started
+
+## Overview
+
+**Unique Strengths:**
+
+1. Only code-gen approach in PHP — 25-63x faster than runtime libraries
+2. TypeScript generation — no other DTO library offers this
+3. JSON Schema bidirectional — both import and export
+4. Reviewable generated code — shows up in PRs, unlike runtime magic
+5. 4 config formats — PHP, XML, YAML, NEON
+6. Framework integrations — CakePHP, Laravel, Symfony adapters
+
+## 1. Define DTOs
+
+Create a `dto.xml` configuration file in your `config/` directory:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="https://github.com/php-collective/dto">
+    <dto name="Car">
+        <field name="color" type="string"/>
+        <field name="isNew" type="bool"/>
+        <field name="distanceTravelled" type="int"/>
+        <field name="value" type="float"/>
+        <field name="owner" type="Owner"/>
+    </dto>
+
+    <dto name="Owner">
+        <field name="name" type="string"/>
+        <field name="birthYear" type="int"/>
+    </dto>
+
+    <dto name="FlyingCar" extends="Car">
+        <field name="maxAltitude" type="int"/>
+    </dto>
+</dtos>
+```
+
+## 2. Generate DTOs
+
+Using the CLI (recommended):
+
+```bash
+# Place dto.xml in config/ directory, then run:
+vendor/bin/dto generate
+
+# Or specify custom paths:
+vendor/bin/dto generate --config-path=dto/ --src-path=app/ --namespace=MyApp
+
+# Preview changes without writing:
+vendor/bin/dto generate --dry-run --verbose
+```
+
+Or programmatically:
+
+```php
+use PhpCollective\Dto\Engine\XmlEngine;
+use PhpCollective\Dto\Generator\ArrayConfig;
+use PhpCollective\Dto\Generator\Builder;
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\Generator;
+use PhpCollective\Dto\Generator\TwigRenderer;
+
+$config = new ArrayConfig(['namespace' => 'App']);
+$engine = new XmlEngine();
+$builder = new Builder($engine, $config);
+$renderer = new TwigRenderer(null, $config);
+$io = new ConsoleIo();
+
+$generator = new Generator($builder, $renderer, $io, $config);
+$generator->generate('config/', 'src/');
+```
+
+## Deployment Strategies
+
+There are two approaches to deploying generated DTOs:
+
+### Commit DTOs to Version Control (Recommended)
+
+Generate DTOs locally, commit them to your repository, and deploy like any other code:
+
+```bash
+composer require --dev php-collective/dto
+```
+
+**Benefits:**
+- DTOs are reviewed in pull requests
+- No generation step needed on production servers
+- Faster deployments
+- Works with read-only filesystems
+
+**Workflow:**
+1. Modify DTO configuration
+2. Run `vendor/bin/dto generate`
+3. Commit generated files
+4. Deploy as usual
+
+### Runtime Generation on Server
+
+Generate DTOs as part of your deployment process:
+
+```bash
+composer require php-collective/dto
+```
+
+**When to use:**
+- Dynamic DTO definitions
+- Environments where committing generated code isn't desired
+
+**Note:** This requires the library in production and write access to the source directory during deployment.
+
+### Exclude Generated DTOs from Static Analysis
+
+Generated DTOs should be excluded from phpcs, phpstan, and similar tools:
+
+**phpcs.xml:**
+```xml
+<exclude-pattern>src/Dto/*</exclude-pattern>
+```
+
+**phpstan.neon:**
+```neon
+parameters:
+    excludePaths:
+        - src/Dto/*
+```
+
+## 3. Use Generated DTOs
+
+```php
+use App\Dto\CarDto;
+use App\Dto\OwnerDto;
+
+// Create with setters
+$carDto = new CarDto();
+$carDto->setColor('black');
+$carDto->setIsNew(true);
+
+// Or create from array
+$carDto = CarDto::createFromArray([
+    'color' => 'red',
+    'isNew' => false,
+    'distanceTravelled' => 50000,
+]);
+
+// Access with getters
+$color = $carDto->getColor();           // string|null
+$isNew = $carDto->getIsNewOrFail();     // bool (throws if not set)
+
+// Check existence
+if ($carDto->hasOwner()) {
+    $owner = $carDto->getOwner();
+}
+
+// Convert back to array
+$array = $carDto->toArray();
+$touched = $carDto->touchedToArray();   // Only fields that were set
+```
+
+## Configuration Formats
+
+The library supports multiple configuration formats:
+
+- **XML** (default) - with XSD validation and IDE autocomplete
+- **YAML** - requires PHP YAML extension (`pecl install yaml`)
+- **NEON** - requires `nette/neon`
+- **PHP** - native PHP arrays, best IDE support for complex configs
+
+### YAML Example
+
+```yaml
+# config/dto.yml
+Car:
+    fields:
+        color: string
+        isNew: bool
+        distanceTravelled:
+            type: int
+            defaultValue: 0
+        owner:
+            type: Owner
+            required: true
+        parts:
+            type: Part[]
+            collection: true
+            singular: part
+
+Owner:
+    fields:
+        name: string
+        birthYear: int
+
+ImmutableConfig:
+    immutable: true
+    fields:
+        apiKey: string
+        timeout:
+            type: int
+            defaultValue: 30
+```
+
+### NEON Example
+
+```neon
+# config/dto.neon
+Car:
+    fields:
+        color: string
+        isNew: bool
+        distanceTravelled:
+            type: int
+            defaultValue: 0
+        owner:
+            type: Owner
+            required: true
+
+Owner:
+    fields:
+        name: string
+        birthYear: int
+```
+
+### PHP Example
+
+```php
+<?php
+// config/dto.php
+return [
+    'Car' => [
+        'fields' => [
+            'color' => 'string',
+            'isNew' => 'bool',
+            'owner' => [
+                'type' => 'Owner',
+                'required' => true,
+            ],
+        ],
+    ],
+    'Owner' => [
+        'fields' => [
+            'name' => 'string',
+        ],
+    ],
+];
+```
+
+### PHP Fluent Builder
+
+For better IDE autocomplete and type safety, use the fluent builder API:
+
+```php
+<?php
+// config/dto.php
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\Field;
+use PhpCollective\Dto\Config\Schema;
+
+return Schema::create()
+    ->dto(Dto::create('Car')->fields(
+        Field::string('color'),
+        Field::bool('isNew'),
+        Field::dto('owner', 'Owner')->required(),
+    ))
+    ->dto(Dto::create('Owner')->fields(
+        Field::string('name'),
+    ))
+    ->toArray();
+```
+
+See [Configuration Builder](./config-builder) for full documentation.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,0 +1,400 @@
+---
+title: Migration Guide
+---
+
+# Migration Guide
+
+How to migrate from other DTO libraries to php-collective/dto.
+
+## From spatie/data-transfer-object
+
+**Note:** spatie/data-transfer-object is deprecated since 2023. Spatie recommends migrating to `spatie/laravel-data` or `cuyz/valinor`.
+
+### Before (spatie/data-transfer-object)
+
+```php
+use Spatie\DataTransferObject\DataTransferObject;
+
+class UserDto extends DataTransferObject
+{
+    public int $id;
+    public string $name;
+    public ?string $email = null;
+    public array $roles = [];
+}
+
+// Usage
+$dto = new UserDto([
+    'id' => 1,
+    'name' => 'John',
+]);
+```
+
+### After (php-collective/dto)
+
+**Step 1: Create configuration**
+
+```xml
+<!-- config/dto.xml -->
+<dtos xmlns="php-collective-dto">
+    <dto name="User">
+        <field name="id" type="int" required="true"/>
+        <field name="name" type="string" required="true"/>
+        <field name="email" type="string"/>
+        <field name="roles" type="string[]" collection="true" singular="role"/>
+    </dto>
+</dtos>
+```
+
+**Step 2: Generate**
+
+```bash
+vendor/bin/dto generate
+```
+
+**Step 3: Update usage**
+
+```php
+use App\Dto\UserDto;
+
+// Same constructor syntax works
+$dto = new UserDto([
+    'id' => 1,
+    'name' => 'John',
+]);
+
+// But now use getters instead of public properties
+$name = $dto->getName();  // Instead of $dto->name
+```
+
+### Key Differences
+
+| Feature | spatie/data-transfer-object | php-collective/dto |
+|---------|---------------------------|-------------------|
+| Properties | Public | Protected + getters/setters |
+| Validation | In-class | Configuration + external |
+| Casters | Attribute-based | Factory methods |
+| Collections | Manual array typing | Built-in collection support |
+
+### Migrating Casters
+
+**Before:**
+
+```php
+use Spatie\DataTransferObject\Caster;
+
+class DateCaster implements Caster
+{
+    public function cast(mixed $value): DateTimeImmutable
+    {
+        return new DateTimeImmutable($value);
+    }
+}
+
+class EventDto extends DataTransferObject
+{
+    #[CastWith(DateCaster::class)]
+    public DateTimeImmutable $date;
+}
+```
+
+**After:**
+
+```xml
+<field name="date" type="\DateTimeImmutable"/>
+```
+
+For custom classes:
+
+```xml
+<field name="money" type="\Money\Money" factory="Money\Parser::parse"/>
+```
+
+---
+
+## From spatie/laravel-data
+
+### Before (spatie/laravel-data)
+
+```php
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Attributes\Validation\Email;
+use Spatie\LaravelData\Attributes\Validation\Required;
+
+class UserData extends Data
+{
+    public function __construct(
+        #[Required]
+        public int $id,
+        #[Required]
+        public string $name,
+        #[Email]
+        public ?string $email = null,
+    ) {}
+}
+
+// Usage
+$data = UserData::from($request);
+$data = UserData::from(['id' => 1, 'name' => 'John']);
+```
+
+### After (php-collective/dto)
+
+```xml
+<dto name="User">
+    <field name="id" type="int" required="true"/>
+    <field name="name" type="string" required="true"/>
+    <field name="email" type="string"/>
+</dto>
+```
+
+```php
+// Similar static constructor
+$dto = UserDto::createFromArray(['id' => 1, 'name' => 'John']);
+
+// Or from request (you handle validation separately)
+$validated = $request->validate([
+    'id' => 'required|integer',
+    'name' => 'required|string',
+    'email' => 'nullable|email',
+]);
+$dto = new UserDto($validated);
+```
+
+### Key Differences
+
+| Feature | spatie/laravel-data | php-collective/dto |
+|---------|--------------------|--------------------|
+| Validation | Built-in attributes | External (see Validation.md) |
+| Laravel integration | Deep | Via collection factory |
+| TypeScript | Built-in | Built-in |
+| Lazy properties | Yes | No (use lazy loading in service layer) |
+| Data pipes | Yes | No (use service layer) |
+
+### Migrating Nested Data
+
+**Before:**
+
+```php
+class OrderData extends Data
+{
+    public function __construct(
+        public CustomerData $customer,
+        /** @var ItemData[] */
+        public array $items,
+    ) {}
+}
+```
+
+**After:**
+
+```xml
+<dto name="Order">
+    <field name="customer" type="Customer"/>
+    <field name="items" type="Item[]" collection="true" singular="item"/>
+</dto>
+```
+
+### Migrating Casts
+
+**Before:**
+
+```php
+class ProductData extends Data
+{
+    public function __construct(
+        public string $name,
+        #[WithCast(MoneyCast::class)]
+        public Money $price,
+    ) {}
+}
+```
+
+**After:**
+
+```xml
+<dto name="Product">
+    <field name="name" type="string"/>
+    <field name="price" type="\Money\Money" factory="Money\Parser::parse"/>
+</dto>
+```
+
+---
+
+## From cuyz/valinor
+
+### Before (cuyz/valinor)
+
+```php
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\MapperBuilder;
+
+final class User
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly ?string $email = null,
+    ) {}
+}
+
+$mapper = (new MapperBuilder())->mapper();
+
+try {
+    $user = $mapper->map(User::class, $source);
+} catch (MappingError $e) {
+    // Handle error
+}
+```
+
+### After (php-collective/dto)
+
+```xml
+<dto name="User" immutable="true">
+    <field name="id" type="int" required="true"/>
+    <field name="name" type="string" required="true"/>
+    <field name="email" type="string"/>
+</dto>
+```
+
+```php
+try {
+    $dto = new UserDto($source);
+} catch (InvalidArgumentException $e) {
+    // Handle error
+}
+```
+
+### Key Differences
+
+| Feature | cuyz/valinor | php-collective/dto |
+|---------|-------------|-------------------|
+| Approach | Runtime mapping | Code generation |
+| Type support | Excellent (generics, shapes) | Good (generics, union) |
+| Error messages | Detailed | Basic |
+| Performance | Moderate (cached) | Best (no reflection) |
+
+---
+
+## From Native PHP readonly Classes
+
+### Before (PHP 8.2+)
+
+```php
+final readonly class UserDto
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public ?string $email = null,
+    ) {}
+}
+
+$dto = new UserDto(id: 1, name: 'John');
+```
+
+### After (php-collective/dto)
+
+```xml
+<dto name="User" immutable="true">
+    <field name="id" type="int" required="true"/>
+    <field name="name" type="string" required="true"/>
+    <field name="email" type="string"/>
+</dto>
+```
+
+```php
+// Array constructor (more flexible for API/form data)
+$dto = new UserDto(['id' => 1, 'name' => 'John']);
+
+// Access via getters
+$name = $dto->getName();
+
+// Immutable updates with with*() methods
+$updated = $dto->withEmail('john@example.com');
+```
+
+### Benefits of Migration
+
+- **Key format conversion**: Automatic snake_case ↔ camelCase
+- **Collection support**: Built-in typed collections
+- **toArray()**: Easy serialization with format options
+- **touchedToArray()**: Partial updates
+- **Deep cloning**: `clone()` method
+- **Nested DTOs**: Automatic hydration from arrays
+
+---
+
+## General Migration Steps
+
+### 1. Install php-collective/dto
+
+```bash
+composer require php-collective/dto
+```
+
+### 2. Create Configuration
+
+Start with your most-used DTOs. Create `config/dto.xml` (or yaml/neon/php):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="php-collective-dto">
+    <!-- Define your DTOs here -->
+</dtos>
+```
+
+### 3. Generate DTOs
+
+```bash
+vendor/bin/dto generate --dry-run --verbose  # Preview
+vendor/bin/dto generate                       # Generate
+```
+
+### 4. Update Usages
+
+Search and replace in your codebase:
+
+| Old Pattern | New Pattern |
+|-------------|-------------|
+| `$dto->property` | `$dto->getProperty()` |
+| `$dto->property = $value` | `$dto->setProperty($value)` |
+| `new Dto($arg1, $arg2)` | `new Dto(['field1' => $arg1, 'field2' => $arg2])` |
+
+### 5. Handle Validation Separately
+
+If your old DTOs had built-in validation, extract it to a validation layer:
+
+```php
+// Before: validation in DTO
+$dto = new UserDto($data);  // Validated internally
+
+// After: explicit validation
+$validated = $this->validator->validate($data, $rules);
+$dto = new UserDto($validated);
+```
+
+See [Validation](./validation) for integration examples.
+
+### 6. Test Thoroughly
+
+- Run your existing test suite
+- Add tests for new DTO behavior
+- Test edge cases (null values, empty collections, etc.)
+
+---
+
+## Feature Comparison Quick Reference
+
+| Feature | spatie/dto | laravel-data | valinor | php-collective/dto |
+|---------|-----------|--------------|---------|-------------------|
+| **Approach** | Runtime | Runtime | Runtime | Generated |
+| **Immutable** | No | Optional | Yes | Optional |
+| **Collections** | Manual | Built-in | Built-in | Built-in |
+| **Validation** | Basic | Full | Good | Required only |
+| **TypeScript** | No | Yes | No | Yes |
+| **Key conversion** | No | Manual | No | Built-in |
+| **IDE support** | Good | Good | Good | Excellent |
+| **Static analysis** | Good | Good | Excellent | Excellent |
+| **Performance** | Good | Moderate | Moderate | Best |
+| **Framework** | Any | Laravel | Any | Any |

--- a/docs/guide/motivation.md
+++ b/docs/guide/motivation.md
@@ -1,0 +1,162 @@
+---
+title: Motivation
+description: Why code generation beats runtime reflection for DTOs
+---
+
+# Motivation and Background
+
+## The Problem with Arrays
+
+Working with complex and nested arrays quickly becomes problematic:
+- In templates, you don't know exactly what keys are available or what the nesting structure looks like
+- No IDE autocomplete or typehinting unless you're inside the same code that created the array
+- No verification of fields and their types with simple associative arrays
+- PHPStan and other introspection tools can't work well with untyped arrays
+
+## The Solution: DTOs
+
+[Data Transfer Objects (DTOs)](https://dzone.com/articles/practical-php/practical-php-patterns-data) are the best approach here, but creating them manually can be tedious.
+
+Some people argue that arrays are faster and use less memory than objects. This might have been true in PHP 5.2, but modern PHP handles objects efficiently.
+
+## Other Existing Solutions
+
+The PHP DTO ecosystem has evolved significantly with PHP 8.x features. Here's the current landscape (2025):
+
+**Active Libraries:**
+- [spatie/laravel-data](https://github.com/spatie/laravel-data) (v4.18+): Laravel-specific, runtime reflection with PHP 8 attributes. Features validation, TypeScript generation, lazy properties, and Eloquent integration. Requires PHP 8.1+.
+- [cuyz/valinor](https://github.com/CuyZ/Valinor) (v2.3+): Framework-agnostic runtime mapper with PHPStan/Psalm type support (generics, shaped arrays, integer ranges). Excellent error messages and normalization support. Requires PHP 8.1+.
+- [symfony/serializer](https://symfony.com/doc/current/serializer.html) (v7/8): Component-based serialization with new JsonStreamer for streaming large datasets. Supports JSON, XML, YAML, CSV.
+- [symfony/object-mapper](https://symfony.com/doc/current/serializer.html) (Symfony 7.3+): New lightweight ObjectMapper component for simple DTO hydration without full Serializer overhead.
+- [jms/serializer](https://github.com/schmittjoh/serializer) (v3.32+): Mature annotation/attribute-driven serializer with versioning, Doctrine integration, and circular reference handling. Requires PHP 7.4+.
+
+**Deprecated:**
+- [spatie/data-transfer-object](https://github.com/spatie/data-transfer-object): **Deprecated as of 2023**. Maintainers recommend `spatie/laravel-data` or `cuyz/valinor`.
+
+**Native PHP 8.2+ (No Library):**
+```php
+final readonly class UserDto
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+    ) {}
+}
+```
+Sufficient for simple cases, but lacks collections, validation, and inflection support.
+
+**Common issues with runtime libraries:**
+- Runtime reflection overhead on every instantiation
+- IDE support limited by "magic" - autocomplete depends on plugin quality
+- Static analysis requires additional annotations or plugins
+
+## Why Generated Code?
+
+This library takes a fundamentally different approach: **code generation instead of runtime reflection**.
+
+Other libraries leverage declared properties and reflection/introspection at runtime to finalize the DTO. What if we let a generator do that for us? Taking the maximum performance benefit from creating a customized object, while having all the addons we want on top for free?
+
+We generate optimized DTOs where all inflection, reflection, validation and asserting is done at generation time. Using them is just as simple as with basic arrays, only with tons of benefits on top.
+
+**Key advantages of code generation:**
+- **Zero runtime reflection** - no performance overhead per instantiation
+- **Excellent IDE support** - real methods mean perfect autocomplete and "Find Usages"
+- **Perfect static analysis** - PHPStan/Psalm work without plugins or annotations
+- **Reviewable code** - generated classes can be inspected in pull requests
+- **No magic** - what you see is exactly what runs
+
+## Comparison with Alternatives
+
+| Aspect                  | php-collective/dto | laravel-data | valinor  | symfony/serializer | jms/serializer | native PHP |
+|-------------------------|:------------------:|:------------:|:--------:|:------------------:|:--------------:|:----------:|
+| **Approach**            |  Code generation   |  Reflection  | Mapping  |     Reflection     |   Reflection   |   Manual   |
+| **IDE Autocomplete**    |     Excellent      |     Good     |   Good   |        Good        |      Good      | Excellent  |
+| **Static Analysis**     |     Excellent      |     Good     | Excellent |        Good        |      Good      | Excellent  |
+| **Runtime Performance** |        Best        |   Moderate   | Moderate |      Moderate      |    Moderate    |    Best    |
+| **Validation**          |   Required only    |     Full     |   Good   |      Partial       |    Partial     |    None    |
+| **TypeScript Gen**      |        Yes         |     Yes      |    No    |         No         |       No       |     No     |
+| **Collections**         |      Built-in      |   Built-in   | Built-in |       Manual       |    Built-in    |   Manual   |
+| **Inflection**          |      Built-in      |    Manual    |  Manual  |       Manual       |     Manual     |   Manual   |
+| **Immutable DTOs**      |      Built-in      |   Built-in   | Built-in |       Manual       |     Manual     |   Manual   |
+| **Lazy Properties**     |         No         |     Yes      |    No    |         No         |       No       |     No     |
+| **Generics Support**    |    PHPDoc only     |   Partial    | Excellent|      Partial       |    Partial     |     No     |
+| **Error Messages**      |       Good         |     Good     | Excellent|        Good        |      Good      |    N/A     |
+| **Framework**           |        Any         |   Laravel    |   Any    |      Symfony       |      Any       |    Any     |
+| **PHP Requirement**     |       8.2+         |    8.1+      |   8.1+   |        8.4+        |      7.4+      |    8.2+    |
+
+**When to choose php-collective/dto:**
+- Performance is critical (25-60x faster than runtime libraries)
+- You want the best possible IDE and static analysis support
+- You prefer configuration files over code attributes
+- You need either mutable or immutable DTOs with explicit choice
+- You work with different key formats (camelCase, snake_case, dashed)
+- Code review of generated DTOs is valuable to your team
+
+## Summary
+
+**Strengths vs competition:**
+
+| Aspect              | php-collective/dto           | Runtime Libraries          |
+|---------------------|------------------------------|----------------------------|
+| IDE/Static Analysis | Excellent (real methods)     | Good (reflection/magic)    |
+| Runtime Performance | Best (25-60x faster)         | Moderate                   |
+| Code Review         | Generated code visible in PR | Magic/runtime behavior     |
+| Inflection Support  | Built-in (snake/camel/dash)  | Usually manual             |
+| Build-time Errors   | Catch issues at generation   | Discover at runtime        |
+
+**Gaps compared to runtime libraries:**
+
+| Feature              | php-collective/dto | laravel-data | valinor  | jms/serializer |
+|----------------------|:------------------:|:------------:|:--------:|:--------------:|
+| Validation Rules     |   Required only    |     Full     |   Good   |    Partial     |
+| Lazy Properties      |         No         |     Yes      |    No    |       No       |
+| Integer Ranges       |         No         |      No      |   Yes    |       No       |
+| API Versioning       |         No         |      No      |    No    |      Yes       |
+| Eloquent Integration |      Not Yet       |     Yes      |    No    |       No       |
+| Streaming/Large Data |         No         |      No      |    No    |       No       |
+
+**Verdict:** php-collective/dto is the **only code-generation approach** in the PHP DTO ecosystem, giving it unique advantages for performance (25-60x faster) and IDE support. Choose runtime libraries if you need advanced validation, lazy loading, or framework-specific integration.
+
+## Why Not Immutable by Default?
+
+Arrays are somewhat immutable, so this is a fair point. The goal was to first make it work for easy use cases and simple usage. For most use cases, mutable objects are a good compromise - allowing easy modifications where needed.
+
+Immutable means we either have to insert all data into the constructor or provide `with...()` methods. This should be a deliberate choice.
+
+## Why the Dto Suffix?
+
+A `Post` or `Article` object will likely clash with existing entities or similar classes. Having to alias in all files is not ideal. Also consider `Date` and other reserved words.
+
+So `PostDto` etc. is easy enough to avoid issues while not being much longer. Inside code it can also be helpful to keep prefixes in variables:
+
+```php
+$postArray = [
+    'title' => 'My cool Post',
+];
+$postDto = new PostDto($postArray);
+```
+
+This makes the code more readable in pull requests or when not directly inside the IDE.
+
+## Why No Interfaces?
+
+Contracting with interfaces is important when building SOLID code. For generated classes it seems like overhead. From a stability perspective, manually modified code shouldn't extend/implement fluently changing generated code. The generated classes always have to be evaluated as a whole.
+
+## Value Objects
+
+[Value objects](https://martinfowler.com/bliki/ValueObject.html) should work nicely with DTOs. Value objects like `DateTime`, `Money`, or custom ones are usually immutable by design.
+
+The key difference: value objects can contain logic and "operations" between each other (`$moneyOne->subtract($moneyTwo)`), whereas a DTO must not contain anything beyond holding pure data and setting/getting.
+
+## Performance Benchmark
+
+Benchmarks show `php-collective/dto` is **25-37x faster** than spatie/laravel-data and **37-63x faster** than cuyz/valinor, while being within 1.2-1.6x of hand-written plain PHP DTOs.
+
+See [Performance Guide](./performance) for detailed benchmarks and optimization tips, or run them yourself:
+
+```bash
+php benchmark/run.php              # Main benchmark suite
+php benchmark/run-external.php     # Compare with other libraries
+```
+
+**Developer speed, code readability and code reliability strongly increase with only a bit of speed decrease** that usually doesn't matter for a normal web request.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -1,0 +1,432 @@
+---
+title: Performance Guide
+---
+
+# Performance Guide
+
+Performance characteristics, benchmarks, and optimization tips.
+
+## Why Generated Code is Fast
+
+php-collective/dto takes a fundamentally different approach than runtime DTO libraries:
+
+| Operation | Runtime Libraries | php-collective/dto |
+|-----------|------------------|-------------------|
+| Class loading | Parse attributes/annotations | Load pre-generated class |
+| Property access | Reflection or magic methods | Direct property access |
+| Type checking | Runtime validation | PHP native types |
+| Key mapping | Runtime calculation | Pre-computed lookup table |
+| Collection creation | Runtime type resolution | Pre-defined factory |
+
+**Result:** Near-native PHP performance with zero reflection overhead per instantiation.
+
+## Benchmark Comparison
+
+### Simple DTO Creation (10,000 iterations)
+
+```
+php-collective/dto:     ~15ms  (baseline)
+Native PHP readonly:    ~12ms  (0.8x)
+spatie/laravel-data:    ~85ms  (5.7x slower)
+cuyz/valinor:           ~120ms (8x slower)
+```
+
+*Benchmarks are indicative. Actual performance varies by PHP version, opcache settings, and DTO complexity.*
+
+### Key Insights
+
+1. **First load**: Generated DTOs are slightly slower on first load (more code to parse), but opcache eliminates this
+2. **Subsequent access**: Generated DTOs match or beat native PHP classes
+3. **Complex DTOs**: The performance gap widens with nested DTOs and collections
+
+## Optimization Tips
+
+### 1. Use opcache in Production
+
+Generated DTOs benefit significantly from opcache:
+
+```ini
+; php.ini
+opcache.enable=1
+opcache.memory_consumption=256
+opcache.max_accelerated_files=20000
+opcache.validate_timestamps=0  ; Disable in production
+```
+
+### 2. Prefer touchedToArray() for Partial Data
+
+```php
+// Slower: serializes all fields
+$data = $dto->toArray();
+
+// Faster: only serializes fields that were set
+$data = $dto->touchedToArray();
+```
+
+Especially important for DTOs with many optional fields.
+
+### 3. Use ignoreMissing for Partial Input
+
+```php
+// Slower: validates every field exists
+$dto = new UserDto($partialData);
+
+// Faster: skips validation for missing fields
+$dto = new UserDto($partialData, ignoreMissing: true);
+```
+
+### 4. Batch Operations
+
+When processing many items, create DTOs in batches:
+
+```php
+// Less efficient: create one at a time
+foreach ($items as $item) {
+    $dtos[] = new ItemDto($item);
+}
+
+// More efficient: use array_map (allows internal optimizations)
+$dtos = array_map(fn($item) => new ItemDto($item), $items);
+```
+
+### 5. Avoid Unnecessary Cloning
+
+```php
+// Unnecessary clone
+$modified = $original->clone();
+$modified->setName('New');
+
+// Better: modify directly if original isn't needed
+$original->setName('New');
+
+// Or use immutable DTOs if you need both versions
+$modified = $original->withName('New');
+```
+
+### 6. Use Appropriate Collection Types
+
+```php
+// ArrayObject: Good for iteration, modification
+<field name="items" type="Item[]" collection="true"/>
+
+// Array: Lighter weight, but no object methods
+<field name="tags" type="string[]" collection="true"/>
+```
+
+For read-heavy workloads, array collections are slightly faster.
+
+### 7. Minimize Nested Depth
+
+Deeply nested DTOs have cumulative overhead:
+
+```php
+// Each level adds instantiation cost
+$order->getCustomer()->getAddress()->getCity()->getName();
+
+// Consider flattening if you frequently access deep values
+$order->getCustomerCity();  // Computed during creation
+```
+
+### 8. Lazy Loading Alternative
+
+php-collective/dto doesn't support lazy properties, but you can implement lazy loading in your service layer:
+
+```php
+class OrderService
+{
+    private ?CustomerDto $customer = null;
+
+    public function getCustomer(OrderDto $order): CustomerDto
+    {
+        if ($this->customer === null) {
+            $this->customer = $this->customerRepository->find($order->getCustomerId());
+        }
+        return $this->customer;
+    }
+}
+```
+
+## Memory Considerations
+
+### Object vs Array Memory
+
+Modern PHP (7.4+) handles objects efficiently:
+
+```php
+// Memory usage is comparable
+$array = ['name' => 'John', 'email' => 'john@example.com'];
+$dto = new UserDto(['name' => 'John', 'email' => 'john@example.com']);
+
+// DTOs may use slightly more memory due to metadata
+// But the difference is negligible for most applications
+```
+
+### Large Collections
+
+For very large collections (10,000+ items), consider:
+
+```php
+// Memory-efficient: process in chunks
+foreach (array_chunk($largeArray, 1000) as $chunk) {
+    $dtos = array_map(fn($item) => new ItemDto($item), $chunk);
+    $this->process($dtos);
+    unset($dtos);  // Free memory
+}
+
+// Or use generators
+function createDtos(array $items): Generator
+{
+    foreach ($items as $item) {
+        yield new ItemDto($item);
+    }
+}
+```
+
+### Circular References
+
+Self-referencing DTOs can cause memory issues:
+
+```php
+// Potential memory issue with deep trees
+$category = new CategoryDto([
+    'children' => [
+        ['children' => [['children' => [...]]]]
+    ],
+]);
+
+// Solution: limit depth or use lazy loading
+```
+
+## Profiling DTOs
+
+### Using Xdebug Profiler
+
+```ini
+; php.ini
+xdebug.mode=profile
+xdebug.output_dir=/tmp/xdebug
+xdebug.profiler_output_name=cachegrind.out.%p
+```
+
+### Using Blackfire
+
+```bash
+blackfire run php your-script.php
+```
+
+### Simple Timing
+
+```php
+$start = microtime(true);
+
+for ($i = 0; $i < 10000; $i++) {
+    $dto = new UserDto(['name' => 'John', 'email' => 'john@example.com']);
+}
+
+$elapsed = microtime(true) - $start;
+echo "Created 10,000 DTOs in {$elapsed}s\n";
+```
+
+## When Performance Matters
+
+### High-Performance Scenarios
+
+- API responses with large datasets
+- Batch data processing
+- Real-time data streaming
+- High-traffic endpoints
+
+### When to Optimize
+
+1. Profile first - identify actual bottlenecks
+2. Optimize hot paths - focus on frequently executed code
+3. Measure after - verify improvements
+
+### When NOT to Optimize
+
+- Low-traffic internal tools
+- One-time data migrations
+- Development/testing environments
+
+The generated code is already optimized. Focus on application-level optimizations before micro-optimizing DTO usage.
+
+## Comparison with Alternatives
+
+### vs Native PHP Classes
+
+```php
+// Native PHP (fastest possible)
+readonly class UserDto {
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {}
+}
+
+// php-collective/dto (nearly as fast, more features)
+// Generated with inflection, validation, collections, etc.
+```
+
+**Trade-off:** ~20% overhead for significantly more functionality.
+
+### vs Runtime Libraries
+
+| Library | Relative Speed | Notes |
+|---------|---------------|-------|
+| php-collective/dto | 1x (baseline) | Generated code |
+| Native readonly | 0.8x faster | No features |
+| spatie/laravel-data | 5-6x slower | Runtime reflection |
+| cuyz/valinor | 6-8x slower | Runtime mapping |
+
+### When Runtime Libraries Win
+
+- Rapid prototyping (no generation step)
+- Dynamic schemas (runtime flexibility)
+- Heavy framework integration (Laravel ecosystem)
+
+### When Generated Code Wins
+
+- Production performance critical
+- Static analysis requirements
+- IDE support requirements
+- Code review requirements (visible generated code)
+
+## Doctrine ORM: Entity vs DTO Benchmark
+
+Using partial array hydration + DTOs significantly improves read performance compared to full entity hydration.
+
+### Benchmark Setup
+
+```php
+// Entity with relations
+#[Entity]
+class User {
+    #[Id, Column]
+    private int $id;
+    #[Column]
+    private string $name;
+    #[Column]
+    private string $email;
+    #[OneToMany(targetEntity: Role::class)]
+    private Collection $roles;
+    #[ManyToOne(targetEntity: Department::class)]
+    private Department $department;
+    // ... 15 more fields
+}
+
+// Lightweight DTO (generated)
+class UserSummaryDto extends AbstractDto {
+    protected int $id;
+    protected string $name;
+    protected string $email;
+}
+```
+
+### Results: Fetching 1,000 Users
+
+```
+Full Entity Hydration:           ~45ms
+  - Hydrates all 18 fields
+  - Creates proxy objects for relations
+  - Tracks in UnitOfWork
+
+Array + DTO Hydration:           ~12ms  (3.7x faster)
+  - Fetches only 3 needed fields
+  - No proxy objects
+  - No UnitOfWork tracking
+
+DTO from Entity->toArray():      ~52ms  (slower than entity alone)
+  - Full entity hydration + conversion overhead
+```
+
+### Memory Usage (1,000 Users)
+
+```
+Full Entity Hydration:     ~2.8 MB
+Array + DTO Hydration:     ~0.4 MB  (7x less memory)
+```
+
+### When to Use Each Approach
+
+| Scenario | Recommendation | Why |
+|----------|---------------|-----|
+| **API list endpoints** | Array + DTO | Only fetch displayed fields |
+| **Admin dashboards** | Array + DTO | Read-only, specific columns |
+| **Entity updates** | Full Entity | Need UnitOfWork for persistence |
+| **Complex business logic** | Full Entity | Need relation traversal |
+| **Export/reports** | Array + DTO | Memory efficient for large sets |
+| **Real-time feeds** | Array + DTO | Minimal latency |
+
+### Benchmark Code
+
+```php
+// Full entity hydration
+$start = microtime(true);
+$users = $em->getRepository(User::class)->findAll();
+foreach ($users as $user) {
+    $data[] = [
+        'id' => $user->getId(),
+        'name' => $user->getName(),
+        'email' => $user->getEmail(),
+    ];
+}
+$entityTime = microtime(true) - $start;
+
+// Array + DTO hydration
+$start = microtime(true);
+$rows = $em->createQuery(
+    'SELECT u.id, u.name, u.email FROM App\Entity\User u'
+)->getArrayResult();
+$users = array_map(fn($row) => new UserSummaryDto($row), $rows);
+$dtoTime = microtime(true) - $start;
+
+echo "Entity: {$entityTime}s, DTO: {$dtoTime}s\n";
+echo "Speedup: " . round($entityTime / $dtoTime, 1) . "x\n";
+```
+
+### Real-World Example: API Endpoint
+
+```php
+// Before: Full entity hydration (slow)
+#[Route('/api/users')]
+public function list(): JsonResponse
+{
+    $users = $this->userRepository->findAll();
+    return $this->json(array_map(fn($u) => [
+        'id' => $u->getId(),
+        'name' => $u->getName(),
+    ], $users));
+}
+
+// After: Array + DTO hydration (3-4x faster)
+#[Route('/api/users')]
+public function list(): JsonResponse
+{
+    $users = $this->userRepository->findSummaries(); // Returns UserSummaryDto[]
+    return $this->json(array_map(fn($u) => $u->toArray(), $users));
+}
+```
+
+### Combined with Pagination
+
+```php
+/**
+ * @return UserSummaryDto[]
+ */
+public function findPaginatedSummaries(int $page, int $limit): array
+{
+    $rows = $this->createQueryBuilder('u')
+        ->select('u.id', 'u.name', 'u.email')
+        ->setFirstResult(($page - 1) * $limit)
+        ->setMaxResults($limit)
+        ->getQuery()
+        ->getArrayResult();
+
+    return array_map(fn($row) => new UserSummaryDto($row), $rows);
+}
+```
+
+The performance gains compound with:
+- More fields on the entity (partial select fetches fewer)
+- More relations (array hydration avoids proxy creation)
+- Larger result sets (memory savings)

--- a/docs/guide/separating-generated-code.md
+++ b/docs/guide/separating-generated-code.md
@@ -1,0 +1,303 @@
+---
+title: Separating Generated Code
+---
+
+# Separating Generated Code
+
+Best practices for keeping generated DTOs separate from hand-written source code.
+
+## Why Separate Generated Code?
+
+Separating generated code from your source directory offers several benefits:
+
+- **Clearer code ownership** - Distinguishes auto-generated files from hand-written code
+- **Easier code review** - Reviewers know generated files don't need manual inspection
+- **Simpler static analysis** - Exclude entire directory from phpcs/phpstan
+- **Git history clarity** - Generated file changes are clearly identifiable
+- **IDE performance** - Some IDEs handle generated code differently
+
+## Directory Structure
+
+### Default Structure
+
+By default, DTOs are generated in `src/Dto/`:
+
+```
+project/
+├── config/
+│   └── dto.xml
+├── src/
+│   ├── Dto/           # Generated DTOs mixed with source
+│   │   ├── UserDto.php
+│   │   └── OrderDto.php
+│   ├── Controller/
+│   └── Service/
+└── composer.json
+```
+
+### Recommended Structure
+
+Move generated DTOs to a separate `generated/` directory:
+
+```
+project/
+├── config/
+│   └── dto.xml
+├── generated/
+│   └── Dto/           # Generated DTOs isolated
+│       ├── UserDto.php
+│       └── OrderDto.php
+├── src/
+│   ├── Controller/    # Hand-written code only
+│   └── Service/
+└── composer.json
+```
+
+## Setup
+
+### 1. Generate to Separate Directory
+
+Use the `--src-path` option to output to `generated/`:
+
+```bash
+vendor/bin/dto generate --src-path=generated/
+```
+
+This creates DTOs in `generated/Dto/` with namespace `App\Dto`.
+
+### 2. Configure Composer Autoloading
+
+Add the generated directory to your `composer.json` autoload configuration:
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/",
+            "App\\Dto\\": "generated/Dto/"
+        }
+    }
+}
+```
+
+Then regenerate the autoloader:
+
+```bash
+composer dump-autoload
+```
+
+### 3. Add Composer Script
+
+Add a convenient script for regeneration:
+
+```json
+{
+    "scripts": {
+        "dto:generate": "dto generate --src-path=generated/",
+        "dto:check": "dto generate --src-path=generated/ --dry-run"
+    }
+}
+```
+
+Now use:
+
+```bash
+composer dto:generate
+```
+
+## Static Analysis Configuration
+
+By design, PHPCS, PHPStan and CO are all excluded already.
+So nothing to be configured here.
+
+## Git Configuration
+
+### Option A: Commit Generated Files (Recommended)
+
+Track generated files in version control for faster deployments:
+
+```gitignore
+# .gitignore
+# Don't ignore generated/ - we want to track these files
+```
+
+**Benefits:**
+- No generation step needed during deployment
+- Changes are visible in pull requests
+- Works with read-only production filesystems
+
+### Option B: Ignore Generated Files
+
+If you prefer runtime generation:
+
+```gitignore
+# .gitignore
+/generated/
+```
+
+Add generation to your deployment script:
+
+```bash
+composer install
+composer dto:generate
+```
+
+## Custom Namespace
+
+If you prefer a different namespace, adjust both CLI and Composer:
+
+```bash
+# Generate with custom namespace
+vendor/bin/dto generate --src-path=generated/ --namespace=Acme\\Transfer
+```
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "Acme\\Transfer\\": "generated/Dto/"
+        }
+    }
+}
+```
+
+## Multiple Applications
+
+For monorepos or multi-module projects:
+
+```
+project/
+├── modules/
+│   ├── billing/
+│   │   ├── config/dto.xml
+│   │   └── generated/Dto/
+│   └── shipping/
+│       ├── config/dto.xml
+│       └── generated/Dto/
+└── composer.json
+```
+
+Generate each module separately:
+
+```bash
+vendor/bin/dto generate \
+  --config-path=modules/billing/config/ \
+  --src-path=modules/billing/generated/ \
+  --namespace=Billing
+
+vendor/bin/dto generate \
+  --config-path=modules/shipping/config/ \
+  --src-path=modules/shipping/generated/ \
+  --namespace=Shipping
+```
+
+Composer autoload:
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "Billing\\Dto\\": "modules/billing/generated/Dto/",
+            "Shipping\\Dto\\": "modules/shipping/generated/Dto/"
+        }
+    }
+}
+```
+
+## TypeScript and JSON Schema
+
+The same pattern applies to other generators:
+
+```bash
+# TypeScript to separate directory
+vendor/bin/dto typescript --output=generated/types/
+
+# JSON Schema to separate directory
+vendor/bin/dto jsonschema --output=generated/schemas/
+```
+
+Project structure:
+
+```
+project/
+├── config/
+│   └── dto.xml
+├── generated/
+│   ├── Dto/           # PHP DTOs
+│   ├── types/         # TypeScript interfaces
+│   └── schemas/       # JSON Schema files
+└── src/
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  check-dtos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - run: composer install
+
+      # Verify DTOs are up to date
+      - run: composer dto:check
+
+      # Or regenerate and check for diff
+      - run: |
+          composer dto:generate
+          git diff --exit-code generated/
+```
+
+### Pre-commit Hook
+
+```bash
+#!/bin/sh
+# .git/hooks/pre-commit
+
+# Check if DTO config changed
+if git diff --cached --name-only | grep -q "config/dto"; then
+    vendor/bin/dto generate --src-path=generated/ --dry-run --quiet
+    if [ $? -ne 0 ]; then
+        echo "DTO configuration changed. Run 'composer dto:generate' and commit the generated files."
+        exit 1
+    fi
+fi
+```
+
+## Complete Example
+
+Here's a complete `composer.json` setup:
+
+```json
+{
+    "name": "acme/my-project",
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/",
+            "App\\Dto\\": "generated/Dto/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Test\\": "tests/"
+        }
+    },
+    "require": {
+        "php": ">=8.1",
+		"php-collective/dto": "^1.0"
+    },
+    "scripts": {
+        "dto:generate": "dto generate --src-path=generated/",
+        "dto:check": "dto generate --src-path=generated/ --dry-run",
+        "dto:typescript": "dto typescript --output=generated/types/",
+        "dto:schema": "dto jsonschema --output=generated/schemas/",
+    }
+}
+```

--- a/docs/guide/shaped-arrays.md
+++ b/docs/guide/shaped-arrays.md
@@ -1,0 +1,94 @@
+---
+title: Shaped Array Types
+---
+
+# Shaped Array Types
+
+## Overview
+
+Generated DTOs include PHPStan/Psalm shaped array annotations for `toArray()` and `createFromArray()` methods, enabling full static analysis of array structures.
+
+## Architecture
+
+The parent `Dto` class provides protected internal methods (`_toArrayInternal()`, `_createFromArrayInternal()`) that contain the serialization logic. Generated DTOs define public `toArray()` and `createFromArray()` methods with shaped array types that call these internal methods.
+
+This design:
+- Avoids LSP (Liskov Substitution Principle) violations
+- Provides clean PHPStan-compatible types
+- Works correctly with DTO inheritance
+
+## Generated Output
+
+Each DTO gets typed methods calling the internal implementation:
+
+```php
+/**
+ * @return array{name: string|null, count: int|null, active: bool|null}
+ */
+public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array
+{
+    return $this->_toArrayInternal($type, $fields, $touched);
+}
+
+/**
+ * @param array{name: string|null, count: int|null, active: bool|null} $data
+ */
+public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static
+{
+    return static::_createFromArrayInternal($data, $ignoreMissing, $type);
+}
+```
+
+## Benefits
+
+1. **IDE Autocomplete** - `$dto->toArray()['na` suggests `name`
+2. **Typo Detection** - `$dto->toArray()['naem']` shows error
+3. **Type Inference** - `['name' => $name] = $dto->toArray()` infers `$name` as `string|null`
+4. **Destructuring Support** - Full type safety when unpacking arrays
+
+## Type Mapping
+
+| DTO Field Type | Shaped Array Type |
+|----------------|-------------------|
+| `string` (nullable) | `string\|null` |
+| `int` (required) | `int` |
+| Nested DTO | `array{...}` (inline nested shape) |
+| `Item[]` collection | `array<int, array{...}>` |
+| Associative collection | `array<string, array{...}>` |
+
+## Nested DTOs
+
+Nested DTOs are resolved to their full shaped array type:
+
+```php
+// Order DTO with Customer DTO field
+/** @return array{id: int|null, customer: array{name: string|null, email: string|null}} */
+```
+
+## Collections
+
+Collections include the element's shaped array type:
+
+```php
+// Order DTO with Item[] collection
+/** @return array{id: int|null, items: array<int, array{name: string|null, price: float|null}>} */
+```
+
+## DTO Inheritance
+
+When a DTO extends another DTO, each defines its own `toArray()` with its specific fields. Since there's no method override (just calling the internal method), PHPStan won't complain about type mismatches.
+
+```php
+// VehicleDto
+/** @return array{brand: string|null, year: int|null} */
+public function toArray(...): array
+
+// CarDto extends VehicleDto
+/** @return array{doors: int|null} */
+public function toArray(...): array
+```
+
+## Related
+
+- [PHPStan Array Shapes Documentation](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes)
+- [Psalm Array Types Documentation](https://psalm.dev/docs/annotating_code/type_syntax/array_types/)

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,0 +1,525 @@
+---
+title: Testing DTOs
+---
+
+# Testing DTOs
+
+Best practices for unit testing and integration testing with DTOs.
+
+## Unit Testing DTOs
+
+### Basic Creation Tests
+
+```php
+use PHPUnit\Framework\TestCase;
+use App\Dto\UserDto;
+
+class UserDtoTest extends TestCase
+{
+    public function testCreateFromArray(): void
+    {
+        $dto = new UserDto([
+            'id' => 1,
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+        ]);
+
+        $this->assertSame(1, $dto->getId());
+        $this->assertSame('John Doe', $dto->getName());
+        $this->assertSame('john@example.com', $dto->getEmail());
+    }
+
+    public function testCreateWithSetters(): void
+    {
+        $dto = new UserDto();
+        $dto->setId(1);
+        $dto->setName('John Doe');
+
+        $this->assertSame(1, $dto->getId());
+        $this->assertSame('John Doe', $dto->getName());
+    }
+}
+```
+
+### Testing Required Fields
+
+```php
+public function testRequiredFieldsThrowException(): void
+{
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage('Required fields missing');
+
+    new UserDto(['name' => 'John']);  // Missing required 'email'
+}
+
+public function testRequiredFieldsPass(): void
+{
+    $dto = new UserDto([
+        'name' => 'John',
+        'email' => 'john@example.com',
+    ]);
+
+    $this->assertSame('john@example.com', $dto->getEmail());
+}
+```
+
+### Testing Default Values
+
+```php
+public function testDefaultValues(): void
+{
+    $dto = new PaginationDto();
+
+    $this->assertSame(1, $dto->getPage());
+    $this->assertSame(20, $dto->getPerPage());
+}
+
+public function testDefaultValuesCanBeOverridden(): void
+{
+    $dto = new PaginationDto(['page' => 5, 'perPage' => 50]);
+
+    $this->assertSame(5, $dto->getPage());
+    $this->assertSame(50, $dto->getPerPage());
+}
+```
+
+### Testing toArray() Conversion
+
+```php
+public function testToArray(): void
+{
+    $dto = new UserDto([
+        'id' => 1,
+        'name' => 'John',
+        'email' => 'john@example.com',
+    ]);
+
+    $array = $dto->toArray();
+
+    $this->assertSame([
+        'id' => 1,
+        'name' => 'John',
+        'email' => 'john@example.com',
+        'phone' => null,  // Optional field
+    ], $array);
+}
+
+public function testTouchedToArray(): void
+{
+    $dto = new UserDto();
+    $dto->setName('John');
+
+    $touched = $dto->touchedToArray();
+
+    $this->assertSame(['name' => 'John'], $touched);
+    $this->assertArrayNotHasKey('email', $touched);
+}
+```
+
+### Testing Key Format Conversion
+
+```php
+public function testToArrayUnderscored(): void
+{
+    $dto = new UserDto([
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+    ]);
+
+    $array = $dto->toArray(UserDto::TYPE_UNDERSCORED);
+
+    $this->assertArrayHasKey('first_name', $array);
+    $this->assertArrayHasKey('last_name', $array);
+}
+
+public function testFromArrayUnderscored(): void
+{
+    $dto = new UserDto();
+    $dto->fromArray([
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+    ], false, UserDto::TYPE_UNDERSCORED);
+
+    $this->assertSame('John', $dto->getFirstName());
+    $this->assertSame('Doe', $dto->getLastName());
+}
+```
+
+## Testing Nested DTOs
+
+```php
+public function testNestedDto(): void
+{
+    $dto = new OrderDto([
+        'id' => 1,
+        'customer' => [
+            'name' => 'John',
+            'email' => 'john@example.com',
+        ],
+    ]);
+
+    $this->assertInstanceOf(CustomerDto::class, $dto->getCustomer());
+    $this->assertSame('John', $dto->getCustomer()->getName());
+}
+
+public function testNestedDtoToArray(): void
+{
+    $dto = new OrderDto([
+        'id' => 1,
+        'customer' => [
+            'name' => 'John',
+        ],
+    ]);
+
+    $array = $dto->toArray();
+
+    $this->assertIsArray($array['customer']);
+    $this->assertSame('John', $array['customer']['name']);
+}
+```
+
+## Testing Collections
+
+```php
+public function testCollectionFromArray(): void
+{
+    $dto = new OrderDto([
+        'items' => [
+            ['productId' => 1, 'quantity' => 2],
+            ['productId' => 2, 'quantity' => 1],
+        ],
+    ]);
+
+    $this->assertCount(2, $dto->getItems());
+    $this->assertSame(1, $dto->getItems()[0]->getProductId());
+}
+
+public function testAddToCollection(): void
+{
+    $dto = new OrderDto();
+    $dto->addItem(new OrderItemDto(['productId' => 1, 'quantity' => 2]));
+    $dto->addItem(new OrderItemDto(['productId' => 2, 'quantity' => 1]));
+
+    $this->assertCount(2, $dto->getItems());
+}
+
+public function testCollectionToArray(): void
+{
+    $dto = new OrderDto();
+    $dto->addItem(new OrderItemDto(['productId' => 1]));
+
+    $array = $dto->toArray();
+
+    $this->assertIsArray($array['items']);
+    $this->assertCount(1, $array['items']);
+    $this->assertSame(1, $array['items'][0]['productId']);
+}
+```
+
+## Testing Immutable DTOs
+
+```php
+public function testImmutableWithMethod(): void
+{
+    $original = new ConfigDto(['timeout' => 30]);
+    $modified = $original->withTimeout(60);
+
+    // Original unchanged
+    $this->assertSame(30, $original->getTimeout());
+    // New instance has new value
+    $this->assertSame(60, $modified->getTimeout());
+    // Different instances
+    $this->assertNotSame($original, $modified);
+}
+
+public function testImmutableChaining(): void
+{
+    $dto = new ConfigDto(['timeout' => 30])
+        ->withTimeout(60)
+        ->withRetries(3)
+        ->withDebug(true);
+
+    $this->assertSame(60, $dto->getTimeout());
+    $this->assertSame(3, $dto->getRetries());
+    $this->assertTrue($dto->getDebug());
+}
+```
+
+## Testing Cloning
+
+```php
+public function testDeepClone(): void
+{
+    $original = new OrderDto([
+        'customer' => ['name' => 'John'],
+    ]);
+
+    $clone = $original->clone();
+    $clone->getCustomer()->setName('Jane');
+
+    // Original unchanged
+    $this->assertSame('John', $original->getCustomer()->getName());
+    // Clone modified
+    $this->assertSame('Jane', $clone->getCustomer()->getName());
+}
+```
+
+## Testing Enums
+
+```php
+public function testEnumFromValue(): void
+{
+    $dto = new OrderDto(['status' => 'pending']);
+
+    $this->assertSame(OrderStatus::Pending, $dto->getStatus());
+}
+
+public function testEnumFromInstance(): void
+{
+    $dto = new OrderDto(['status' => OrderStatus::Shipped]);
+
+    $this->assertSame(OrderStatus::Shipped, $dto->getStatus());
+}
+
+public function testEnumToArray(): void
+{
+    $dto = new OrderDto(['status' => OrderStatus::Pending]);
+
+    $array = $dto->toArray();
+
+    $this->assertSame('pending', $array['status']);
+}
+```
+
+## Testing Serialization
+
+```php
+public function testJsonSerialization(): void
+{
+    $dto = new UserDto(['name' => 'John', 'email' => 'john@example.com']);
+
+    $json = $dto->serialize();
+    $decoded = json_decode($json, true);
+
+    $this->assertSame('John', $decoded['name']);
+}
+
+public function testNativeSerialization(): void
+{
+    $original = new UserDto(['name' => 'John']);
+
+    $serialized = serialize($original);
+    $restored = unserialize($serialized);
+
+    $this->assertInstanceOf(UserDto::class, $restored);
+    $this->assertSame('John', $restored->getName());
+}
+
+public function testFromUnserialized(): void
+{
+    $original = new UserDto(['name' => 'John']);
+    $json = $original->serialize();
+
+    $restored = UserDto::fromUnserialized($json);
+
+    $this->assertSame('John', $restored->getName());
+}
+```
+
+## Integration Testing
+
+### Testing with Services
+
+```php
+class UserServiceTest extends TestCase
+{
+    public function testCreateUser(): void
+    {
+        $dto = new CreateUserDto([
+            'name' => 'John',
+            'email' => 'john@example.com',
+        ]);
+
+        $result = $this->userService->create($dto);
+
+        $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertNotNull($result->getId());
+    }
+}
+```
+
+### Testing API Responses
+
+```php
+public function testApiResponse(): void
+{
+    $response = $this->get('/api/users/1');
+
+    $response->assertStatus(200);
+
+    $dto = new UserDto($response->json());
+
+    $this->assertSame(1, $dto->getId());
+    $this->assertNotNull($dto->getName());
+}
+```
+
+### Testing Form Handling
+
+```php
+public function testFormSubmission(): void
+{
+    $formData = [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'email' => 'john@example.com',
+    ];
+
+    $dto = new UserDto();
+    $dto->fromArray($formData, false, UserDto::TYPE_UNDERSCORED);
+
+    $this->assertSame('John', $dto->getFirstName());
+    $this->assertSame('Doe', $dto->getLastName());
+}
+```
+
+## Test Data Builders
+
+For complex DTOs, consider a builder pattern:
+
+```php
+class UserDtoBuilder
+{
+    private array $data = [
+        'id' => 1,
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+    ];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function withId(int $id): self
+    {
+        $this->data['id'] = $id;
+        return $this;
+    }
+
+    public function withName(string $name): self
+    {
+        $this->data['name'] = $name;
+        return $this;
+    }
+
+    public function withEmail(string $email): self
+    {
+        $this->data['email'] = $email;
+        return $this;
+    }
+
+    public function build(): UserDto
+    {
+        return new UserDto($this->data);
+    }
+}
+
+// Usage in tests
+$dto = UserDtoBuilder::create()
+    ->withName('Custom Name')
+    ->build();
+```
+
+## Collection Factory in Tests
+
+Reset the collection factory between tests to avoid state pollution:
+
+```php
+protected function tearDown(): void
+{
+    parent::tearDown();
+    Dto::setCollectionFactory(null);
+    Dto::setDefaultKeyType(null);
+}
+
+public function testWithLaravelCollection(): void
+{
+    Dto::setCollectionFactory(fn($items) => collect($items));
+
+    $dto = new OrderDto([
+        'items' => [['productId' => 1], ['productId' => 2]],
+    ]);
+
+    $filtered = $dto->getItems()->filter(fn($item) => $item->getProductId() === 1);
+
+    $this->assertCount(1, $filtered);
+}
+```
+
+## Data Providers
+
+Use data providers for testing multiple scenarios:
+
+```php
+/**
+ * @dataProvider validUserDataProvider
+ */
+public function testValidUserData(array $data, string $expectedName): void
+{
+    $dto = new UserDto($data);
+
+    $this->assertSame($expectedName, $dto->getName());
+}
+
+public static function validUserDataProvider(): array
+{
+    return [
+        'simple' => [
+            ['name' => 'John', 'email' => 'john@example.com'],
+            'John',
+        ],
+        'with spaces' => [
+            ['name' => 'John Doe', 'email' => 'john@example.com'],
+            'John Doe',
+        ],
+        'unicode' => [
+            ['name' => 'Jöhn Döe', 'email' => 'john@example.com'],
+            'Jöhn Döe',
+        ],
+    ];
+}
+
+/**
+ * @dataProvider invalidUserDataProvider
+ */
+public function testInvalidUserData(array $data, string $expectedError): void
+{
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage($expectedError);
+
+    new UserDto($data);
+}
+
+public static function invalidUserDataProvider(): array
+{
+    return [
+        'missing email' => [
+            ['name' => 'John'],
+            'Required fields missing',
+        ],
+        'unknown field' => [
+            ['name' => 'John', 'email' => 'j@e.com', 'unknown' => 'x'],
+            'Missing field',
+        ],
+    ];
+}
+```
+
+## Tips
+
+1. **Test the edges**: Empty collections, null values, maximum lengths
+2. **Test roundtrips**: `toArray()` → `fromArray()` → `toArray()` should be idempotent
+3. **Test immutability**: Verify originals remain unchanged
+4. **Test key formats**: If you use multiple formats, test conversions
+5. **Reset global state**: Clear collection factory and default key type in tearDown

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,424 @@
+---
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+Common issues, error messages, and debugging tips.
+
+## Exception Reference
+
+### Runtime Exceptions (Using DTOs)
+
+#### `InvalidArgumentException: Required fields missing: {fields}`
+
+**Cause:** Creating a DTO without providing required field values.
+
+```php
+// This throws - 'email' is required
+$user = new UserDto(['name' => 'John']);
+```
+
+**Fix:** Provide all required fields:
+
+```php
+$user = new UserDto(['name' => 'John', 'email' => 'john@example.com']);
+```
+
+---
+
+#### `InvalidArgumentException: Missing field '{field}' in '{DtoClass}' for type '{type}'`
+
+**Cause:** Passing an unknown field name when `ignoreMissing` is false.
+
+```php
+// 'unknownField' doesn't exist in UserDto
+$user = new UserDto(['unknownField' => 'value']);
+```
+
+**Fix:** Either fix the field name or ignore missing fields:
+
+```php
+// Option 1: Use correct field name
+$user = new UserDto(['name' => 'value']);
+
+// Option 2: Ignore unknown fields
+$user = new UserDto(['unknownField' => 'value'], ignoreMissing: true);
+```
+
+---
+
+#### `RuntimeException: Field does not exist: {field}`
+
+**Cause:** Using `get()`, `set()`, or `has()` with an invalid field name.
+
+```php
+$dto->get('nonExistentField');
+$dto->set('invalidField', 'value');
+```
+
+**Fix:** Use a valid field name. Check available fields with:
+
+```php
+$validFields = $dto->fields();
+```
+
+---
+
+#### `InvalidArgumentException: Invalid field lookup for type '{type}': '{field}' does not exist`
+
+**Cause:** Using inflected key type (underscored/dashed) but the field mapping doesn't exist.
+
+```php
+$dto->toArray(Dto::TYPE_UNDERSCORED);  // Field not in keyMap
+```
+
+**Fix:** Ensure the DTO was generated with key mapping, or use default type:
+
+```php
+$dto->toArray();  // Use default camelCase
+```
+
+---
+
+#### `InvalidArgumentException: Type of field '{field}' is '{actual}', expected '{expected}'`
+
+**Cause:** Assigning a value with wrong type to an immutable DTO.
+
+```php
+$dto = new ImmutableDto(['count' => 'not-a-number']);  // Expected int
+```
+
+**Fix:** Provide correct types:
+
+```php
+$dto = new ImmutableDto(['count' => 42]);
+```
+
+---
+
+#### `RuntimeException: Unknown field(s) '{fields}' in serialized data`
+
+**Cause:** Unserializing data that contains fields not in the DTO.
+
+```php
+$serialized = '{"name":"John","deletedField":"value"}';
+$dto = unserialize($serialized);  // 'deletedField' no longer exists
+```
+
+**Fix:** This typically happens after removing fields from a DTO. Clean up serialized data or recreate it.
+
+---
+
+#### `RuntimeException: Factory method '{method}' does not exist on class '{class}'`
+
+**Cause:** The factory method specified in configuration doesn't exist.
+
+```xml
+<field name="date" type="\DateTime" factory="nonExistentMethod"/>
+```
+
+**Fix:** Ensure the factory method exists and is static:
+
+```php
+class DateTime {
+    public static function createFromFormat(...) { ... }
+}
+```
+
+---
+
+#### `InvalidArgumentException: Expected UnitEnum instance`
+
+**Cause:** Internal error when serializing a non-enum value marked as unit enum.
+
+**Fix:** Ensure enum fields contain valid enum instances.
+
+### Generation Exceptions
+
+#### `InvalidArgumentException: DTO name missing, but required`
+
+**Cause:** DTO definition without a name.
+
+```xml
+<dto>  <!-- Missing name attribute -->
+    <field name="id" type="int"/>
+</dto>
+```
+
+**Fix:**
+
+```xml
+<dto name="User">
+    <field name="id" type="int"/>
+</dto>
+```
+
+---
+
+#### `InvalidArgumentException: Invalid DTO name '{name}'`
+
+**Cause:** DTO name contains invalid characters or is a reserved word.
+
+**Fix:** Use valid PHP class names (PascalCase, no special characters).
+
+---
+
+#### `InvalidArgumentException: Field attribute '{field}:type' missing`
+
+**Cause:** Field defined without a type.
+
+```xml
+<field name="id"/>  <!-- Missing type -->
+```
+
+**Fix:**
+
+```xml
+<field name="id" type="int"/>
+```
+
+---
+
+#### `InvalidArgumentException: Invalid field type '{type}'... expected a collection`
+
+**Cause:** Using `collection="true"` without array type notation.
+
+```xml
+<field name="items" type="Item" collection="true"/>  <!-- Should be Item[] -->
+```
+
+**Fix:**
+
+```xml
+<field name="items" type="Item[]" collection="true" singular="item"/>
+```
+
+---
+
+#### `InvalidArgumentException: Extended DTO is immutable / not immutable`
+
+**Cause:** Mixing mutable and immutable inheritance.
+
+```xml
+<dto name="Base" immutable="true">...</dto>
+<dto name="Child" extends="Base">...</dto>  <!-- Error: Child is mutable -->
+```
+
+**Fix:** Both parent and child must have same immutability:
+
+```xml
+<dto name="Base" immutable="true">...</dto>
+<dto name="Child" extends="Base" immutable="true">...</dto>
+```
+
+---
+
+#### `InvalidArgumentException: Invalid singular name '{name}'... already exists as field`
+
+**Cause:** Singular name for collection conflicts with existing field.
+
+```xml
+<dto name="Order">
+    <field name="item" type="string"/>
+    <field name="items" type="Item[]" collection="true" singular="item"/>  <!-- Conflict! -->
+</dto>
+```
+
+**Fix:** Use a different singular name:
+
+```xml
+<field name="items" type="Item[]" collection="true" singular="orderItem"/>
+```
+
+### Configuration File Exceptions
+
+#### `RuntimeException: XML parsing failed`
+
+**Cause:** Malformed XML syntax.
+
+**Fix:** Validate XML syntax. Common issues:
+- Unclosed tags
+- Invalid characters
+- Missing quotes around attributes
+
+#### `InvalidArgumentException: Invalid YAML/NEON file`
+
+**Cause:** Syntax error in YAML or NEON file.
+
+**Fix:** Validate file syntax using online validators or IDE plugins.
+
+## Common Pitfalls
+
+### 1. Mutable Reference Sharing
+
+```php
+$owner = new OwnerDto(['name' => 'John']);
+$car1 = new CarDto();
+$car2 = new CarDto();
+
+$car1->setOwner($owner);
+$car2->setOwner($owner);
+
+// Modifying owner affects BOTH cars!
+$owner->setName('Jane');
+echo $car1->getOwner()->getName();  // 'Jane'
+echo $car2->getOwner()->getName();  // 'Jane'
+```
+
+**Fix:** Clone when needed:
+
+```php
+$car1->setOwner($owner->clone());
+$car2->setOwner($owner->clone());
+```
+
+Or use immutable DTOs.
+
+### 2. Key Map Direction Confusion
+
+The `_keyMap` maps **inflected name → field name**, not the reverse:
+
+```php
+// CORRECT
+'underscored' => [
+    'first_name' => 'firstName',  // inflected => field
+],
+
+// WRONG
+'underscored' => [
+    'firstName' => 'first_name',  // This is backwards!
+],
+```
+
+### 3. Forgetting ignoreMissing for Partial Data
+
+```php
+// API returns only some fields
+$partialData = ['name' => 'John'];  // Missing 'email', 'age', etc.
+
+// This throws if those fields don't exist in DTO
+$dto = new UserDto($partialData);
+
+// Use ignoreMissing for partial data
+$dto = new UserDto($partialData, ignoreMissing: true);
+```
+
+### 4. Circular Reference in toArray()
+
+Self-referencing DTOs can cause infinite loops:
+
+```php
+$parent = new CategoryDto(['name' => 'Electronics']);
+$child = new CategoryDto(['name' => 'Phones', 'parent' => $parent]);
+$parent->addChild($child);
+$child->setParent($parent);
+
+// This may cause infinite recursion!
+$array = $parent->toArray();
+```
+
+**Fix:** Use `touchedToArray()` or manually handle the serialization.
+
+### 5. Collection Factory Not Set Early Enough
+
+```php
+// WRONG: DTOs created before factory is set
+$dto = new OrderDto($data);
+Dto::setCollectionFactory(fn($items) => collect($items));
+// Items are still ArrayObject, not Laravel Collection
+
+// CORRECT: Set factory before any DTO instantiation
+Dto::setCollectionFactory(fn($items) => collect($items));
+$dto = new OrderDto($data);
+// Now items are Laravel Collection
+```
+
+### 6. Type Coercion Assumptions
+
+PHP's native type system handles some coercion, but not all:
+
+```php
+// Works: string "123" coerced to int
+$dto = new UserDto(['id' => '123']);
+echo $dto->getId();  // int 123
+
+// Fails: "abc" cannot become int
+$dto = new UserDto(['id' => 'abc']);
+// TypeError
+```
+
+## Debugging
+
+### Using __debugInfo()
+
+```php
+$dto = new UserDto(['name' => 'John']);
+var_dump($dto);
+
+// Output:
+// object(UserDto)#1 {
+//   ["data"] => ["name" => "John", "email" => null, ...]
+//   ["touched"] => ["name"]
+//   ["extends"] => "PhpCollective\Dto\Dto\AbstractDto"
+//   ["immutable"] => false
+// }
+```
+
+### Inspecting Touched Fields
+
+```php
+$dto = new UserDto();
+$dto->setName('John');
+
+// See which fields were explicitly set
+$touched = $dto->touchedFields();
+// ['name']
+
+// Get only touched values
+$changes = $dto->touchedToArray();
+// ['name' => 'John']
+```
+
+### Checking Available Fields
+
+```php
+$dto = new UserDto();
+
+// List all fields
+$fields = $dto->fields();
+// ['id', 'name', 'email', ...]
+
+// Check if field exists
+if (in_array('email', $dto->fields())) {
+    // Field exists
+}
+```
+
+### JSON Output for Debugging
+
+```php
+$dto = new UserDto($data);
+
+// Pretty-printed JSON
+echo json_encode($dto->toArray(), JSON_PRETTY_PRINT);
+```
+
+### Dry Run Generation
+
+```bash
+# See what would be generated without writing files
+vendor/bin/dto generate --dry-run --verbose
+```
+
+## Getting Help
+
+If you encounter issues not covered here:
+
+1. Check the [GitHub Issues](https://github.com/php-collective/dto/issues)
+2. Search existing issues for similar problems
+3. Open a new issue with:
+   - PHP version
+   - Library version
+   - Minimal reproduction code
+   - Full error message and stack trace

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -1,0 +1,264 @@
+---
+title: Validation
+---
+
+# Validation
+
+This document explains what validation php-collective/dto provides and how to integrate with validation libraries for more complex rules.
+
+## Built-in Validation
+
+### Required Fields
+
+When a field is marked as `required`, the DTO will throw an exception if that field is missing or null during instantiation.
+
+```xml
+<dto name="User">
+    <field name="id" type="int" required="true"/>
+    <field name="email" type="string" required="true"/>
+    <field name="nickname" type="string"/>  <!-- optional -->
+</dto>
+```
+
+```php
+// This throws InvalidArgumentException: Required fields missing: email
+$user = new UserDto(['id' => 1]);
+
+// This works - nickname is optional
+$user = new UserDto(['id' => 1, 'email' => 'test@example.com']);
+```
+
+### Validation Rules
+
+Fields support built-in validation rules for common constraints:
+
+```php
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\Field;
+use PhpCollective\Dto\Config\Schema;
+
+return Schema::create()
+    ->dto(Dto::create('User')->fields(
+        Field::string('name')->required()->minLength(2)->maxLength(100),
+        Field::string('email')->required()->pattern('/^[^@]+@[^@]+\.[^@]+$/'),
+        Field::int('age')->min(0)->max(150),
+        Field::float('score')->min(0.0)->max(100.0),
+    ))
+    ->toArray();
+```
+
+Or in XML:
+
+```xml
+<dto name="User">
+    <field name="name" type="string" required="true" minLength="2" maxLength="100"/>
+    <field name="email" type="string" required="true" pattern="/^[^@]+@[^@]+\.[^@]+$/"/>
+    <field name="age" type="int" min="0" max="150"/>
+    <field name="score" type="float" min="0" max="100"/>
+</dto>
+```
+
+#### Available Rules
+
+| Rule | Applies To | Description |
+|------|-----------|-------------|
+| `minLength` | string | Minimum string length (via `mb_strlen`) |
+| `maxLength` | string | Maximum string length (via `mb_strlen`) |
+| `min` | int, float | Minimum numeric value (inclusive) |
+| `max` | int, float | Maximum numeric value (inclusive) |
+| `pattern` | string | Regex pattern that must match (via `preg_match`) |
+
+#### Behavior
+
+- Null fields skip validation — rules are only checked when a value is present
+- Required check runs before validation rules
+- On failure, an `InvalidArgumentException` is thrown with a descriptive message:
+
+```php
+// InvalidArgumentException: Validation failed: name must be at least 2 characters
+$user = new UserDto(['name' => 'A', 'email' => 'a@b.com']);
+
+// InvalidArgumentException: Validation failed: email must match pattern /^[^@]+@[^@]+\.[^@]+$/
+$user = new UserDto(['name' => 'Test', 'email' => 'invalid']);
+```
+
+## Integrating with Validation Libraries
+
+### Symfony Validator
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
+
+// Create your DTO
+$userDto = new UserDto($formData);
+
+// Define constraints separately
+$constraints = new Assert\Collection([
+    'email' => [new Assert\NotBlank(), new Assert\Email()],
+    'age' => [new Assert\Range(['min' => 18, 'max' => 120])],
+    'name' => [new Assert\Length(['min' => 2, 'max' => 100])],
+]);
+
+// Validate
+$validator = Validation::createValidator();
+$violations = $validator->validate($userDto->toArray(), $constraints);
+
+if (count($violations) > 0) {
+    foreach ($violations as $violation) {
+        echo $violation->getPropertyPath() . ': ' . $violation->getMessage();
+    }
+}
+```
+
+### Laravel Validation (Standalone)
+
+```php
+use Illuminate\Validation\Factory;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+
+$loader = new ArrayLoader();
+$translator = new Translator($loader, 'en');
+$factory = new Factory($translator);
+
+$validator = $factory->make($userDto->toArray(), [
+    'email' => 'required|email',
+    'age' => 'required|integer|min:18|max:120',
+    'name' => 'required|string|min:2|max:100',
+]);
+
+if ($validator->fails()) {
+    $errors = $validator->errors()->all();
+}
+```
+
+### Respect/Validation
+
+```php
+use Respect\Validation\Validator as v;
+
+$userValidator = v::key('email', v::email())
+    ->key('age', v::intVal()->between(18, 120))
+    ->key('name', v::stringType()->length(2, 100));
+
+try {
+    $userValidator->assert($userDto->toArray());
+} catch (\Respect\Validation\Exceptions\NestedValidationException $e) {
+    $errors = $e->getMessages();
+}
+```
+
+### Webmozart Assert (Simple Assertions)
+
+For simple assertions without full validation framework:
+
+```php
+use Webmozart\Assert\Assert;
+
+$data = $userDto->toArray();
+
+Assert::email($data['email'], 'Invalid email format');
+Assert::range($data['age'], 18, 120, 'Age must be between 18 and 120');
+Assert::lengthBetween($data['name'], 2, 100, 'Name must be 2-100 characters');
+```
+
+## Validation in Controllers
+
+A common pattern is to validate before creating the DTO:
+
+```php
+class UserController
+{
+    public function create(Request $request): Response
+    {
+        // 1. Validate raw input first
+        $validated = $this->validate($request->all(), [
+            'email' => 'required|email',
+            'name' => 'required|string|max:100',
+        ]);
+
+        // 2. Create DTO from validated data
+        $userDto = new UserDto($validated);
+
+        // 3. Process the DTO
+        $this->userService->create($userDto);
+
+        return new Response('Created');
+    }
+}
+```
+
+Or validate the DTO after creation:
+
+```php
+class UserController
+{
+    public function create(Request $request): Response
+    {
+        // 1. Create DTO (handles type coercion, required fields)
+        $userDto = new UserDto($request->all());
+
+        // 2. Validate business rules
+        $this->validator->validate($userDto->toArray(), $this->getUserRules());
+
+        // 3. Process
+        $this->userService->create($userDto);
+
+        return new Response('Created');
+    }
+}
+```
+
+## Type Coercion vs Validation
+
+The library performs **type coercion**, not validation:
+
+```php
+// String "123" is coerced to int 123
+$dto = new UserDto(['id' => '123', 'email' => 'test@example.com']);
+echo $dto->getId(); // int 123
+
+// But invalid types throw TypeError
+$dto = new UserDto(['id' => 'not-a-number', 'email' => 'test@example.com']);
+// TypeError: Cannot assign string to property UserDto::$id of type int
+```
+
+This is PHP's native type system at work, not library validation.
+
+## Summary
+
+| Feature | php-collective/dto | Validation Library |
+|---------|:------------------:|:------------------:|
+| Required fields | ✅ | ✅ |
+| Type checking | ✅ (PHP native) | ✅ |
+| Min/max length | ✅ | ✅ |
+| Numeric ranges | ✅ | ✅ |
+| Regex patterns | ✅ | ✅ |
+| Email/URL format | ✅ (via pattern) | ✅ |
+| Custom rules | ❌ | ✅ |
+| Error messages | Basic | Rich |
+
+**Recommendation:** Use the built-in validation rules for simple structural constraints. For complex business logic validation (conditional rules, cross-field dependencies, custom messages), use a dedicated validation library alongside your DTOs.
+
+## Extracting Rules for Framework Validation
+
+The `validationRules()` method returns a framework-agnostic array of validation rules from the DTO metadata. This is useful for bridging DTO rules to framework-native validators:
+
+```php
+$dto = new UserDto();
+$rules = $dto->validationRules();
+// [
+//     'name' => ['required' => true, 'minLength' => 2, 'maxLength' => 50],
+//     'email' => ['pattern' => '/^[^@]+@[^@]+\.[^@]+$/'],
+//     'age' => ['min' => 0, 'max' => 150],
+// ]
+```
+
+Only fields with at least one active rule are included. The returned keys match the config rule names: `required`, `minLength`, `maxLength`, `min`, `max`, `pattern`.
+
+The framework integration plugins provide ready-made bridges:
+
+- **CakePHP:** `DtoValidator::fromDto($dto)` → `Cake\Validation\Validator`
+- **Laravel:** `DtoValidationRules::fromDto($dto)` → Laravel rule arrays
+- **Symfony:** `DtoConstraintBuilder::fromDto($dto)` → `Symfony\Component\Validator\Constraints\Collection`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,106 @@
+---
+layout: home
+
+hero:
+  name: PHP DTO
+  text: Code Generation for Data Transfer Objects
+  tagline: Framework-agnostic DTOs with zero runtime overhead, perfect IDE support, and TypeScript generation.
+  image:
+    src: /logo.svg
+    alt: PHP DTO
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/php-collective/dto
+
+features:
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+    title: 25-63x Faster
+    details: Code generation at build time means zero runtime reflection. The only code-gen approach in PHP for DTOs.
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+    title: Perfect IDE Support
+    details: Generated methods give you full autocomplete, go-to-definition, and refactoring support in any IDE.
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>
+    title: TypeScript Generation
+    details: Generate TypeScript interfaces directly from your DTO configs. Keep frontend and backend types in sync.
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+    title: Reviewable Code
+    details: Generated DTOs show up in pull requests. No hidden magic—review exactly what your DTOs look like.
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" x2="22" y1="12" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+    title: JSON Schema Support
+    details: Bidirectional JSON Schema—both import and export. Bootstrap DTOs from APIs or generate documentation.
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22h14a2 2 0 0 0 2-2V7.5L14.5 2H6a2 2 0 0 0-2 2v4"/><polyline points="14 2 14 8 20 8"/><path d="m3 15 2 2 4-4"/></svg>
+    title: Multiple Config Formats
+    details: Define DTOs in PHP, XML, YAML, or NEON. XML includes XSD validation with IDE autocomplete.
+---
+
+<style>
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: -webkit-linear-gradient(120deg, #7c3aed 30%, #ec4899);
+}
+</style>
+
+## Quick Example
+
+Define your DTOs with the fluent PHP builder:
+
+```php
+// config/dto.php
+use PhpCollective\Dto\Config\{Dto, Field, Schema};
+
+return Schema::create()
+    ->dto(Dto::create('User')->fields(
+        Field::int('id')->required(),
+        Field::string('name')->required(),
+        Field::string('email')->required(),
+        Field::dto('address', 'Address'),
+    ))
+    ->dto(Dto::create('Address')->fields(
+        Field::string('street'),
+        Field::string('city'),
+        Field::string('country'),
+    ))
+    ->toArray();
+```
+
+Generate and use:
+
+```bash
+vendor/bin/dto generate
+```
+
+```php
+$user = UserDto::createFromArray($apiResponse);
+
+$user->getName();           // string
+$user->getAddress();        // AddressDto|null
+$user->getAddressOrFail();  // AddressDto (throws if null)
+```
+
+## Installation
+
+```bash
+composer require php-collective/dto
+```
+
+## Framework Integrations
+
+<div class="integration-links">
+
+| Framework | Package |
+|-----------|---------|
+| CakePHP | [dereuromark/cakephp-dto](https://github.com/dereuromark/cakephp-dto) |
+| Laravel | [php-collective/laravel-dto](https://github.com/php-collective/laravel-dto) |
+| Symfony | [php-collective/symfony-dto](https://github.com/php-collective/symfony-dto) |
+
+</div>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,2338 @@
+{
+  "name": "dto-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dto-docs",
+      "devDependencies": {
+        "vitepress": "^1.6.3"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.15.2.tgz",
+      "integrity": "sha512-rF7vRVE61E0QORw8e2NNdnttcl3jmFMWS9B4hhdga12COe+lMa26bQLfcBn/Nbp9/AF/8gXdaRCPsVns3CnjsA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.49.2.tgz",
+      "integrity": "sha512-XyvKCm0RRmovMI/ChaAVjTwpZhXdbgt3iZofK914HeEHLqD1MUFFVLz7M0+Ou7F56UkHXwRbpHwb9xBDNopprQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.49.2.tgz",
+      "integrity": "sha512-jq/3qvtmj3NijZlhq7A1B0Cl41GfaBpjJxcwukGsYds6aMSCWrEAJ9pUqw/C9B3hAmILYKl7Ljz3N9SFvekD3Q==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.49.2.tgz",
+      "integrity": "sha512-bn0biLequn3epobCfjUqCxlIlurLr4RHu7RaE4trgN+RDcUq6HCVC3/yqq1hwbNYpVtulnTOJzcaxYlSr1fnuw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.49.2.tgz",
+      "integrity": "sha512-z14wfFs1T3eeYbCArC8pvntAWsPo9f6hnUGoj8IoRUJTwgJiiySECkm8bmmV47/x0oGHfsVn3kBdjMX0yq0sNA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.49.2.tgz",
+      "integrity": "sha512-GpRf7yuuAX93+Qt0JGEJZwgtL0MFdjFO9n7dn8s2pA9mTjzl0Sc5+uTk1VPbIAuf7xhCP9Mve+URGb6J+EYxgA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.49.2.tgz",
+      "integrity": "sha512-HZwApmNkp0DiAjZcLYdQLddcG4Agb88OkojiAHGgcm5DVXobT5uSZ9lmyrbw/tmQBJwgu2CNw4zTyXoIB7YbPA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.2.tgz",
+      "integrity": "sha512-y1IOpG6OSmTpGg/CT0YBb/EAhR2nsC18QWp9Jy8HO9iGySpcwaTvs5kHa17daP3BMTwWyaX9/1tDTDQshZzXdg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.49.2.tgz",
+      "integrity": "sha512-YYJRjaZ2bqk923HxE4um7j/Cm3/xoSkF2HC2ZweOF8cXL3sqnlndSUYmCaxHFjNPWLaSHk2IfssX6J/tdKTULw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.49.2.tgz",
+      "integrity": "sha512-9WgH+Dha39EQQyGKCHlGYnxW/7W19DIrEbCEbnzwAMpGAv1yTWCHMPXHxYa+LcL3eCp2V/5idD1zHNlIKmHRHg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.49.2.tgz",
+      "integrity": "sha512-K7Gp5u+JtVYgaVpBxF5rGiM+Ia8SsMdcAJMTDV93rwh00DKNllC19o1g+PwrDjDvyXNrnTEbofzbTs2GLfFyKA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.49.2.tgz",
+      "integrity": "sha512-3UhYCcWX6fbtN8ABcxZlhaQEwXFh3CsFtARyyadQShHMPe3mJV9Wel4FpJTa+seugRkbezFz0tt6aPTZSYTBuA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.49.2.tgz",
+      "integrity": "sha512-G94VKSGbsr+WjsDDOBe5QDQ82QYgxvpxRGJfCHZBnYKYsy/jv9qGIDb93biza+LJWizQBUtDj7bZzp3QZyzhPQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.49.2.tgz",
+      "integrity": "sha512-UuihBGHafG/ENsrcTGAn5rsOffrCIRuHMOsD85fZGLEY92ate+BMTUqxz60dv5zerh8ZumN4bRm8eW2z9L11jA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.73",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.73.tgz",
+      "integrity": "sha512-nQZTwul4c2zBqH/aLP4zMOiElj93T6HawbrP+sFQKpxmBdS5x1duCK3cAnkj6dntHz84EYkzaQRM83V2pj4qxA==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "dev": true
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.2.tgz",
+      "integrity": "sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/abtesting": "1.15.2",
+        "@algolia/client-abtesting": "5.49.2",
+        "@algolia/client-analytics": "5.49.2",
+        "@algolia/client-common": "5.49.2",
+        "@algolia/client-insights": "5.49.2",
+        "@algolia/client-personalization": "5.49.2",
+        "@algolia/client-query-suggestions": "5.49.2",
+        "@algolia/client-search": "5.49.2",
+        "@algolia/ingestion": "1.49.2",
+        "@algolia/monitoring": "1.49.2",
+        "@algolia/recommend": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dto-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3"
+  }
+}

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7c3aed"/>
+      <stop offset="100%" style="stop-color:#ec4899"/>
+    </linearGradient>
+  </defs>
+  <!-- Box/Container representing DTO -->
+  <rect x="16" y="24" width="96" height="80" rx="12" fill="url(#grad)"/>
+  <!-- Data lines -->
+  <rect x="32" y="44" width="40" height="8" rx="4" fill="white" opacity="0.9"/>
+  <rect x="32" y="60" width="56" height="8" rx="4" fill="white" opacity="0.7"/>
+  <rect x="32" y="76" width="32" height="8" rx="4" fill="white" opacity="0.5"/>
+  <!-- Arrow indicating transfer -->
+  <path d="M88 64 L104 64 M98 56 L106 64 L98 72" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,306 @@
+---
+title: CLI Reference
+---
+
+# CLI Reference
+
+Complete reference for the DTO Generator command-line interface.
+
+## Installation
+
+After installing via Composer, the CLI is available at:
+
+```bash
+vendor/bin/dto
+```
+
+## Commands
+
+### generate (default)
+
+Generate PHP DTOs from configuration files.
+
+```bash
+vendor/bin/dto generate [options]
+```
+
+This is the default command, so `vendor/bin/dto` is equivalent to `vendor/bin/dto generate`.
+
+### typescript
+
+Generate TypeScript interfaces from configuration files.
+
+```bash
+vendor/bin/dto typescript [options]
+```
+
+### jsonschema
+
+Generate JSON Schema from configuration files.
+
+```bash
+vendor/bin/dto jsonschema [options]
+```
+
+## Common Options
+
+Options available for all commands:
+
+| Option | Description |
+|--------|-------------|
+| `--config-path=PATH` | Path to config directory (default: `config/`) |
+| `--format=FORMAT` | Config format: `xml`, `yaml`, `neon`, `php` (default: auto-detect) |
+| `--verbose`, `-v` | Verbose output with detailed information |
+| `--quiet`, `-q` | Minimal output, only errors |
+| `--help`, `-h` | Show help message |
+
+## Generate Options
+
+Options specific to PHP DTO generation:
+
+| Option | Description |
+|--------|-------------|
+| `--src-path=PATH` | Path to src directory (default: `src/`) |
+| `--namespace=NS` | Namespace for generated DTOs (default: `App`) |
+| `--dry-run` | Show what would be generated without writing files |
+| `--force` | Regenerate all DTOs, even if unchanged |
+| `--confirm` | Validate PHP syntax of generated files |
+| `--mapper` | Generate Doctrine-compatible mapper classes |
+
+## TypeScript Options
+
+Options specific to TypeScript generation:
+
+| Option | Description |
+|--------|-------------|
+| `--output=PATH` | Path for TypeScript output (default: `types/`) |
+| `--single-file` | Generate all types in one file (default) |
+| `--multi-file` | Generate each type in separate file |
+| `--readonly` | Make all interface fields readonly |
+| `--strict-nulls` | Use `\| null` instead of `?` for nullable fields |
+| `--file-case=CASE` | File naming: `pascal`, `dashed`, `snake` (default: `pascal`) |
+
+## JSON Schema Options
+
+Options specific to JSON Schema generation:
+
+| Option | Description |
+|--------|-------------|
+| `--output=PATH` | Path for JSON Schema output (default: `schemas/`) |
+| `--single-file` | Generate all schemas in one file with `$defs` (default) |
+| `--multi-file` | Generate each schema in separate file |
+| `--no-refs` | Inline nested DTOs instead of using `$ref` |
+| `--date-format=FMT` | Date format: `date-time`, `date`, `string` (default: `date-time`) |
+
+## Examples
+
+### Basic Generation
+
+```bash
+# Generate with defaults (config/ -> src/Dto/)
+vendor/bin/dto generate
+
+# Same as above (generate is default command)
+vendor/bin/dto
+```
+
+### Custom Paths
+
+```bash
+# Custom config and output paths
+vendor/bin/dto generate --config-path=dto/ --src-path=app/
+
+# Custom namespace
+vendor/bin/dto generate --namespace=MyApp\\Dto
+
+# All custom
+vendor/bin/dto generate \
+  --config-path=definitions/ \
+  --src-path=lib/ \
+  --namespace=Acme\\Data
+```
+
+### Preview and Debug
+
+```bash
+# See what would be generated without writing
+vendor/bin/dto generate --dry-run
+
+# Verbose output for debugging
+vendor/bin/dto generate --dry-run --verbose
+
+# Validate generated PHP syntax
+vendor/bin/dto generate --confirm
+```
+
+### Force Regeneration
+
+```bash
+# Regenerate all DTOs, ignoring timestamps
+vendor/bin/dto generate --force
+```
+
+### Doctrine Mapper Generation
+
+```bash
+# Generate DTOs with Doctrine-compatible mapper classes
+vendor/bin/dto generate --mapper
+
+# Creates:
+#   src/Dto/UserDto.php           - Standard DTO
+#   src/Dto/Mapper/UserDtoMapper.php - Mapper with positional constructor
+```
+
+The mapper classes extend the DTOs with positional constructors for use with Doctrine's `SELECT NEW` syntax. See [Framework Integration](/guide/framework-integration#doctrine-select-new-with-mappers) for usage details.
+
+### TypeScript Generation
+
+```bash
+# Generate TypeScript interfaces (single file)
+vendor/bin/dto typescript
+
+# Custom output directory
+vendor/bin/dto typescript --output=frontend/src/types/
+
+# Separate files with dashed naming
+vendor/bin/dto typescript --multi-file --file-case=dashed
+# Creates: user-dto.ts, order-dto.ts, etc.
+
+# Readonly interfaces with strict nulls
+vendor/bin/dto typescript --readonly --strict-nulls
+```
+
+### JSON Schema Generation
+
+```bash
+# Generate JSON Schema (single file with $defs)
+vendor/bin/dto jsonschema
+
+# Custom output directory
+vendor/bin/dto jsonschema --output=api/schemas/
+
+# Separate files with external $ref
+vendor/bin/dto jsonschema --multi-file
+# Creates: UserDto.json, OrderDto.json, etc.
+
+# Inline nested DTOs instead of using $ref
+vendor/bin/dto jsonschema --no-refs
+
+# Custom date format
+vendor/bin/dto jsonschema --date-format=date
+```
+
+### CI/CD Integration
+
+```bash
+# In CI pipeline - fail if DTOs are outdated
+vendor/bin/dto generate --dry-run
+if [ $? -ne 0 ]; then
+  echo "DTOs are not up to date. Run 'vendor/bin/dto generate' locally."
+  exit 1
+fi
+
+# Or validate syntax after generation
+vendor/bin/dto generate --confirm
+```
+
+## Configuration File Discovery
+
+The CLI auto-detects configuration files in the following order:
+
+1. **Single file**: `{config-path}/dto.{ext}` where `{ext}` is xml, yaml, neon, or php
+2. **Multiple files**: `{config-path}/dto/*.{ext}`
+
+### Format Detection
+
+When `--format` is not specified:
+
+1. Checks file extension
+2. For directories, scans for first recognized format
+3. Falls back to XML
+
+### Multiple Configuration Files
+
+You can split DTOs across multiple files:
+
+```
+config/
+└── dto/
+    ├── user.xml
+    ├── order.xml
+    └── product.xml
+```
+
+All files in the directory are merged during generation.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (invalid config, generation failure, etc.) |
+
+## Environment Variables
+
+The CLI respects standard environment variables:
+
+| Variable | Effect |
+|----------|--------|
+| `NO_COLOR` | Disables colored output |
+| `TERM=dumb` | Disables colored output |
+
+## Scripting
+
+### Composer Scripts
+
+Add to `composer.json`:
+
+```json
+{
+  "scripts": {
+    "dto:generate": "dto generate",
+    "dto:generate-mapper": "dto generate --mapper",
+    "dto:check": "dto generate --dry-run",
+    "dto:typescript": "dto typescript --output=frontend/types/",
+    "dto:schema": "dto jsonschema --output=api/schemas/"
+  }
+}
+```
+
+Then run:
+
+```bash
+composer dto:generate
+composer dto:check
+```
+
+### Git Hooks
+
+Pre-commit hook to ensure DTOs are current:
+
+```bash
+#!/bin/sh
+# .git/hooks/pre-commit
+
+vendor/bin/dto generate --dry-run --quiet
+if [ $? -ne 0 ]; then
+  echo "Error: DTO configuration has changed."
+  echo "Run 'vendor/bin/dto generate' and commit the generated files."
+  exit 1
+fi
+```
+
+### Makefile
+
+```makefile
+.PHONY: dto dto-check dto-typescript
+
+dto:
+	vendor/bin/dto generate
+
+dto-check:
+	vendor/bin/dto generate --dry-run
+
+dto-typescript:
+	vendor/bin/dto typescript --output=frontend/src/types/
+```

--- a/docs/reference/importer.md
+++ b/docs/reference/importer.md
@@ -1,0 +1,425 @@
+---
+title: Schema Importer
+---
+
+# Schema Importer
+
+The Importer utility helps you quickly bootstrap DTO configurations from existing JSON data or JSON Schema definitions. This is useful when integrating with external APIs or migrating from other systems.
+
+## Quick Start
+
+```php
+use PhpCollective\Dto\Importer\Importer;
+
+$importer = new Importer();
+
+// From JSON data example with nested object
+$json = '{
+    "id": 1,
+    "name": "John",
+    "email": "john@example.com",
+    "address": {
+        "street": "123 Main St",
+        "city": "New York",
+        "zipCode": "10001"
+    }
+}';
+echo $importer->import($json);
+```
+
+Output (PHP config format):
+```php
+<?php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\DtoBuilder;
+use PhpCollective\Dto\Config\Field;
+
+return DtoBuilder::create()
+    ->dtos(
+        Dto::create('Object')->fields(
+            Field::int('id'),
+            Field::string('name'),
+            Field::string('email'),
+            Field::dto('address', 'Address'),
+        ),
+        Dto::create('Address')->fields(
+            Field::string('street'),
+            Field::string('city'),
+            Field::string('zipCode'),
+        ),
+    )
+    ->build();
+```
+
+## Input Types
+
+The Importer supports two input types:
+
+### 1. JSON Data (auto-detected)
+
+Pass an example JSON response and the importer will infer types:
+
+```php
+$json = '{
+    "user": {
+        "name": "John",
+        "email": "john@example.com"
+    },
+    "items": [
+        {"id": 1, "name": "Item 1"},
+        {"id": 2, "name": "Item 2"}
+    ]
+}';
+
+$result = $importer->import($json);
+```
+
+Features:
+- Infers scalar types (string, int, float, bool)
+- Detects nested objects and creates separate DTOs
+- Detects arrays of objects (collections)
+- Auto-detects potential associative array keys (slug, name, id, login)
+- Converts field names to camelCase
+
+### 2. JSON Schema
+
+Pass a JSON Schema definition for more precise control:
+
+```php
+$schema = json_encode([
+    'type' => 'object',
+    'title' => 'User',
+    'properties' => [
+        'name' => ['type' => 'string'],
+        'age' => ['type' => 'integer'],
+        'email' => ['type' => 'string'],
+    ],
+    'required' => ['name', 'email'],
+]);
+
+$result = $importer->import($schema);
+```
+
+Features:
+- Uses `title` for DTO name
+- Respects `required` array for field validation
+- Handles `anyOf`/`oneOf` type unions
+- Resolves `$ref` pointers to `$defs`, `definitions`, and `components/schemas`
+- Resolves external file `$ref` pointers when `basePath` is provided
+- Normalizes types (integer→int, boolean→bool, number→float)
+
+### 3. OpenAPI Documents
+
+Pass an OpenAPI 3.x specification and all schemas from `components/schemas` will be imported:
+
+```php
+$openapi = json_encode([
+    'openapi' => '3.0.0',
+    'info' => ['title' => 'My API', 'version' => '1.0.0'],
+    'components' => [
+        'schemas' => [
+            'User' => [
+                'type' => 'object',
+                'properties' => [
+                    'id' => ['type' => 'integer'],
+                    'name' => ['type' => 'string'],
+                    'profile' => ['$ref' => '#/components/schemas/Profile'],
+                ],
+                'required' => ['id', 'name'],
+            ],
+            'Profile' => [
+                'type' => 'object',
+                'properties' => [
+                    'bio' => ['type' => 'string'],
+                    'avatar' => ['type' => 'string'],
+                ],
+            ],
+        ],
+    ],
+]);
+
+$result = $importer->import($openapi);
+```
+
+Features:
+- Auto-detects OpenAPI documents (requires `openapi` key and `components/schemas`)
+- Parses all object schemas from `components/schemas`
+- Resolves `$ref` pointers between schemas
+- Handles collections with `$ref` in array items
+- Skips non-object schemas (enums, primitives)
+
+### 4. Schema Inheritance (allOf)
+
+JSON Schema's `allOf` keyword is used to express inheritance. When a schema uses `allOf` with a `$ref`, the importer creates a DTO that extends the referenced type:
+
+```php
+$schema = json_encode([
+    '$defs' => [
+        'BaseEntity' => [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer'],
+                'createdAt' => ['type' => 'string', 'format' => 'date-time'],
+            ],
+        ],
+    ],
+    'type' => 'object',
+    'title' => 'User',
+    'allOf' => [
+        ['$ref' => '#/$defs/BaseEntity'],
+        [
+            'type' => 'object',
+            'properties' => [
+                'email' => ['type' => 'string'],
+                'name' => ['type' => 'string'],
+            ],
+            'required' => ['email'],
+        ],
+    ],
+]);
+
+$result = $importer->import($schema);
+```
+
+Output (PHP config format):
+```php
+<?php
+
+use PhpCollective\Dto\Config\Dto;
+use PhpCollective\Dto\Config\DtoBuilder;
+use PhpCollective\Dto\Config\Field;
+
+return DtoBuilder::create()
+    ->dtos(
+        Dto::create('BaseEntity')->fields(
+            Field::int('id'),
+            Field::string('createdAt'),
+        ),
+        Dto::create('User')->extends('BaseEntity')->fields(
+            Field::string('email')->required(),
+            Field::string('name'),
+        ),
+    )
+    ->build();
+```
+
+Features:
+- Detects `allOf` with `$ref` as inheritance
+- Creates separate DTOs for parent and child
+- Child DTO only includes its own properties (not inherited ones)
+- Merges properties from multiple inline schemas in `allOf`
+- Merges `required` arrays from all schemas
+
+## Output Formats
+
+### PHP (default)
+
+```php
+$importer->import($json, ['format' => 'php']);
+```
+
+### XML
+
+```php
+$importer->import($json, ['format' => 'xml']);
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dtos xmlns="https://php-collective.github.io/dto/schema">
+    <dto name="User">
+        <field name="name" type="string" required="true"/>
+        <field name="email" type="string"/>
+    </dto>
+</dtos>
+```
+
+### YAML
+
+```php
+$importer->import($json, ['format' => 'yaml']);
+```
+
+```yaml
+User:
+  fields:
+    name:
+      type: string
+      required: true
+    email:
+      type: string
+```
+
+### NEON
+
+```php
+$importer->import($json, ['format' => 'neon']);
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `type` | Force parser type: `'Data'` or `'Schema'` | Auto-detected |
+| `format` | Output format: `'php'`, `'xml'`, `'yaml'`, `'neon'` | `'php'` |
+| `namespace` | Namespace prefix for generated DTOs | None |
+| `basePath` | Base directory for external file `$ref` resolution | None |
+| `refResolver` | Custom `$ref` resolver (implements `RefResolverInterface`) | Default file resolver |
+
+### Namespace Example
+
+```php
+$importer->import($json, ['namespace' => 'Api/Response']);
+```
+
+Generates DTOs like `Api/Response/User`, `Api/Response/Address`, etc.
+
+### External `$ref` Example
+
+```php
+$schema = json_encode([
+    'type' => 'object',
+    'properties' => [
+        'user' => ['$ref' => 'schemas/user.json#/definitions/User'],
+    ],
+]);
+
+$result = $importer->import($schema, ['basePath' => __DIR__ . '/openapi']);
+```
+
+## Step-by-Step Usage
+
+For more control, you can use the two-step process:
+
+```php
+// Step 1: Parse to intermediate format
+$definitions = $importer->parse($json, ['type' => 'Data']);
+
+// Inspect or modify definitions
+var_dump($definitions);
+// [
+//     'User' => [
+//         'name' => ['type' => 'string'],
+//         'age' => ['type' => 'int'],
+//     ],
+// ]
+
+// Step 2: Build schema output
+$schema = $importer->buildSchema($definitions, ['format' => 'xml']);
+```
+
+### Working with Arrays
+
+```php
+// Parse array directly (no JSON encoding needed)
+$data = ['name' => 'John', 'age' => 30];
+$definitions = $importer->parseArray($data);
+
+// Or use the convenience method
+$schema = $importer->importArray($data, ['format' => 'php']);
+```
+
+## Type Inference
+
+### From JSON Data
+
+| JSON Value | Inferred Type |
+|------------|---------------|
+| `"string"` | `string` |
+| `123` | `int` |
+| `12.34` | `float` |
+| `true`/`false` | `bool` |
+| `null` | `mixed` |
+| `{...}` | Nested DTO |
+| `[{...}, {...}]` | Collection (`Dto[]`) |
+| `["a", "b"]` | `array` |
+
+### From JSON Schema
+
+| JSON Schema Type | DTO Type |
+|------------------|----------|
+| `string` | `string` |
+| `integer` | `int` |
+| `number` | `float` |
+| `boolean` | `bool` |
+| `array` (of objects) | Collection |
+| `object` | Nested DTO |
+| `["string", "null"]` | `string` (optional) |
+
+### Format Specifiers
+
+| JSON Schema Format | DTO Type |
+|--------------------|----------|
+| `date-time` | `\DateTimeInterface` |
+| `date` | `\DateTimeInterface` |
+| `email`, `uri`, `uuid`, etc. | `string` (unchanged) |
+
+Note: Only `date-time` and `date` formats are mapped to class types. Other formats like `email`, `uri`, `uuid` remain as `string` since they are validation hints rather than type indicators.
+
+### Enums with `x-enum-class`
+
+The importer can map JSON Schema enums to PHP enums if you provide an explicit class hint via a vendor extension.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["pending", "confirmed"],
+      "x-enum-class": "App\\Enum\\OrderStatus"
+    }
+  }
+}
+```
+
+The importer will set the field type to `\App\Enum\OrderStatus` in the generated config.
+
+## Limitations
+
+The importer is a scaffolding tool. Generated configs typically need manual refinement:
+
+1. **Enum detection needs a hint** - Use `x-enum-class` or update the field manually
+2. **No custom types** - DateTime, custom classes need manual configuration
+3. **Limited validation** - Only `required` from JSON Schema is used
+4. **Type inference from data** - Single example may not represent all cases
+5. **Remote `$ref` not supported** - URL references (http/https) require a custom resolver
+
+Example:
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["pending", "confirmed"]
+    }
+  }
+}
+```
+
+The importer will generate a `string` field for `status`. You must update it to `Field::enum(...)` (or set `type` to your enum class) in the DTO config.
+
+## Example: API Response
+
+```php
+// Fetch from API
+$response = file_get_contents('https://api.example.com/users/1');
+
+// Generate DTO config
+$importer = new Importer();
+$config = $importer->import($response, [
+    'namespace' => 'Api/User',
+    'format' => 'php',
+]);
+
+// Save to config file
+file_put_contents('config/dto/api-user.php', $config);
+```
+
+Then review and refine the generated config:
+- Add `required()` to mandatory fields
+- Change types for enums, dates, etc.
+- Add `mapFrom()`/`mapTo()` for field name mapping
+- Configure `factory()`/`serialize()` for custom types

--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -1,0 +1,210 @@
+---
+title: TypeScript Generation
+---
+
+# TypeScript Generation
+
+Generate TypeScript interfaces directly from your DTO configuration files.
+
+## Quick Start
+
+```bash
+# Generate TypeScript interfaces (single file)
+vendor/bin/dto typescript --config-path=config/ --output=frontend/src/types/
+
+# Generate separate files with dashed naming
+vendor/bin/dto typescript --multi-file --file-case=dashed --output=types/
+```
+
+## CLI Options
+
+```
+TypeScript Options:
+  --output=PATH        Path for TypeScript output (default: types/)
+  --single-file        Generate all types in one file (default)
+  --multi-file         Generate each type in separate file
+  --readonly           Make all fields readonly
+  --strict-nulls       Use '| null' instead of '?'
+  --file-case=CASE     File naming: pascal, dashed, snake (default: pascal)
+```
+
+## Examples
+
+### Single File Output (Default)
+
+```bash
+vendor/bin/dto typescript --output=frontend/src/types/
+```
+
+Creates `types/dto.ts`:
+
+```typescript
+// Auto-generated TypeScript definitions from php-collective/dto
+// Do not edit directly - regenerate from DTO configuration
+
+export interface UserDto {
+    id: number;
+    name: string;
+    email: string;
+    phone?: string;
+    active: boolean;
+}
+
+export interface AddressDto {
+    street: string;
+    city: string;
+    country: string;
+}
+
+export interface OrderDto {
+    id: number;
+    customer: UserDto;
+    shippingAddress: AddressDto;
+    items?: OrderItemDto[];
+    total: number;
+}
+```
+
+### Multi-File Output
+
+```bash
+vendor/bin/dto typescript --multi-file --file-case=dashed --output=types/
+```
+
+Creates:
+- `types/user-dto.ts`
+- `types/address-dto.ts`
+- `types/order-dto.ts`
+- `types/index.ts` (re-exports all)
+
+With proper imports:
+
+```typescript
+// types/order-dto.ts
+import type { UserDto } from './user-dto';
+import type { AddressDto } from './address-dto';
+import type { OrderItemDto } from './order-item-dto';
+
+export interface OrderDto {
+    id: number;
+    customer: UserDto;
+    shippingAddress: AddressDto;
+    items?: OrderItemDto[];
+    total: number;
+}
+```
+
+### Readonly Interfaces
+
+For immutable DTOs or when you want all fields readonly:
+
+```bash
+vendor/bin/dto typescript --readonly --output=types/
+```
+
+```typescript
+export interface UserDto {
+    readonly id: number;
+    readonly name: string;
+    readonly email: string;
+}
+```
+
+Note: Immutable DTOs automatically get `readonly` fields regardless of this flag.
+
+### Strict Null Handling
+
+By default, optional fields use `?`:
+
+```typescript
+email?: string;  // default
+```
+
+With `--strict-nulls`:
+
+```typescript
+email: string | null;  // explicit null union
+```
+
+## Type Mapping
+
+| PHP Type | TypeScript Type |
+|----------|-----------------|
+| `int`, `integer` | `number` |
+| `float`, `double` | `number` |
+| `string` | `string` |
+| `bool`, `boolean` | `boolean` |
+| `array` | `any[]` |
+| `string[]` | `string[]` |
+| `int[]` | `number[]` |
+| `mixed` | `unknown` |
+| `object` | `Record<string, unknown>` |
+| `DateTime` | `string` |
+| Other DTO | Interface reference |
+
+## File Naming Options
+
+| Option | Example |
+|--------|---------|
+| `pascal` (default) | `UserDto.ts` |
+| `dashed` | `user-dto.ts` |
+| `snake` | `user_dto.ts` |
+
+## Comparison with Other Libraries
+
+| Library | TypeScript Generation | Approach |
+|---------|----------------------|----------|
+| **php-collective/dto** | Built-in | Generates from config files |
+| **spatie/laravel-data** | Built-in | Runtime reflection of PHP classes |
+| **spatie/typescript-transformer** | Standalone | Transforms PHP classes |
+| **cuyz/valinor** | No | Runtime-only |
+| **symfony/serializer** | No | Runtime-only |
+
+### Advantages of Config-Based Generation
+
+1. **No PHP Runtime Required** - Can generate TypeScript in CI without executing PHP code
+2. **Single Source of Truth** - Both PHP and TypeScript generated from same config
+3. **Full Type Information** - Required fields, defaults, and collections preserved
+4. **Framework Agnostic** - Works without Laravel, Symfony, etc.
+5. **Build-Time Safety** - Type errors caught before deployment
+
+## CI/CD Integration
+
+Add TypeScript generation to your build process:
+
+```yaml
+# GitHub Actions example
+- name: Generate TypeScript types
+  run: vendor/bin/dto typescript --output=frontend/src/types/
+
+- name: Check TypeScript
+  run: cd frontend && npm run type-check
+```
+
+## Programmatic Usage
+
+```php
+use PhpCollective\Dto\Engine\XmlEngine;
+use PhpCollective\Dto\Generator\ArrayConfig;
+use PhpCollective\Dto\Generator\Builder;
+use PhpCollective\Dto\Generator\ConsoleIo;
+use PhpCollective\Dto\Generator\TypeScriptGenerator;
+
+$config = new ArrayConfig(['namespace' => 'App']);
+$engine = new XmlEngine();
+$builder = new Builder($engine, $config);
+$io = new ConsoleIo();
+
+// Build definitions from config
+$definitions = $builder->build('config/', []);
+
+// Generate TypeScript
+$tsGenerator = new TypeScriptGenerator($io, [
+    'singleFile' => false,
+    'fileNameCase' => 'dashed',
+    'readonly' => false,
+    'strictNulls' => false,
+]);
+
+$tsGenerator->generate($definitions, 'frontend/src/types/');
+```


### PR DESCRIPTION
## Summary

- Adds a beautiful VitePress-powered documentation site
- Migrates all existing markdown docs to organized structure (guide/ and reference/)  
- Configures GitHub Actions for automatic deployment to GitHub Pages
- Custom purple theme with gradient branding
- Local search support
- Mobile-responsive sidebar navigation

## After Merge

1. Go to repository Settings → Pages
2. Set Source to "GitHub Actions"
3. The workflow will deploy on next push to master

Docs will be available at: https://php-collective.github.io/dto/

## Preview

The site includes:
- **Homepage** with feature highlights and quick examples
- **Guide section** with all tutorials and configuration docs
- **Reference section** for CLI, TypeScript, and Schema Importer docs
- **Local search** for finding content quickly
- **Dark mode** support
- **Edit on GitHub** links on every page