### PR TITLE
Fix Generator path regex to tolerate either directory separator

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -243,17 +243,25 @@ class Generator
 
         $directory = new RecursiveDirectoryIterator($path);
         $iterator = new RecursiveIteratorIterator($directory);
+        $suffix = $this->config->get('suffix', 'Dto');
+        // Match both `src/Dto/...` (Linux/macOS) and `src\Dto\...` (Windows).
+        // RecursiveDirectoryIterator yields paths using the host OS separator,
+        // so the previous forward-slash-only pattern never matched on Windows
+        // and the "delete DTOs no longer in the spec" pass silently no-op'd,
+        // leaving stale generated files behind.
+        $pattern = '#[/\\\\]src[/\\\\]Dto[/\\\\](.+)' . preg_quote($suffix, '#') . '\.php$#';
         foreach ($iterator as $fileInfo) {
             $file = $fileInfo->getPathname();
-            $suffix = $this->config->get('suffix', 'Dto');
-            if (!preg_match('#src/Dto/(.+)' . preg_quote($suffix, '#') . '\.php$#', $file, $matches)) {
+            if (!preg_match($pattern, $file, $matches)) {
                 continue;
             }
             // Skip mapper files
             if (str_contains($file, DIRECTORY_SEPARATOR . 'Mapper' . DIRECTORY_SEPARATOR)) {
                 continue;
             }
-            $name = $matches[1];
+            // Normalize captured nested paths so `Sub/Foo` and `Sub\\Foo`
+            // don't both land in the result map as separate entries.
+            $name = strtr($matches[1], '\\', '/');
             $files[$name] = $file;
         }
 
@@ -275,13 +283,15 @@ class Generator
 
         $directory = new RecursiveDirectoryIterator($path);
         $iterator = new RecursiveIteratorIterator($directory);
+        $suffix = $this->config->get('suffix', 'Dto');
+        // Same DS-tolerant pattern as findExistingDtos — see comment there.
+        $pattern = '#[/\\\\]Mapper[/\\\\](.+)' . preg_quote($suffix, '#') . 'Mapper\.php$#';
         foreach ($iterator as $fileInfo) {
             $file = $fileInfo->getPathname();
-            $suffix = $this->config->get('suffix', 'Dto');
-            if (!preg_match('#Mapper/(.+)' . preg_quote($suffix, '#') . 'Mapper\.php$#', $file, $matches)) {
+            if (!preg_match($pattern, $file, $matches)) {
                 continue;
             }
-            $name = $matches[1];
+            $name = strtr($matches[1], '\\', '/');
             $files[$name] = $file;
         }
 

--- a/tests/Generator/GeneratorTest.php
+++ b/tests/Generator/GeneratorTest.php
@@ -11,6 +11,7 @@ use PhpCollective\Dto\Generator\Generator;
 use PhpCollective\Dto\Generator\IoInterface;
 use PhpCollective\Dto\Generator\RendererInterface;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 /**
  * Tests for Generator class.
@@ -53,6 +54,91 @@ class GeneratorTest extends TestCase
         } finally {
             @rmdir($tempDir . 'Dto');
             @rmdir($tempDir);
+        }
+    }
+
+    /**
+     * Regression: `findExistingDtos()` matched `#src/Dto/(.+)<suffix>\.php$#`
+     * which hardcoded forward slashes. On Windows the RecursiveDirectoryIterator
+     * yields paths with backslashes and the regex never matched — so the
+     * "delete DTOs no longer in the spec" pass silently no-op'd, leaving stale
+     * generated files behind. The replacement pattern accepts either
+     * separator and normalizes captured nested paths to `/` so the same
+     * nested entry isn't double-counted across OSes.
+     *
+     * Exercising the Windows path directly on a Linux CI box is awkward, so
+     * the now-DS-tolerant regex is driven via a temp-dir round trip on the
+     * host OS path layout and the test additionally asserts that nested-
+     * directory entries get normalized to the canonical forward-slash form.
+     *
+     * @return void
+     */
+    public function testFindExistingDtosToleratesEitherDirectorySeparator(): void
+    {
+        $generator = new Generator(
+            $this->createMock(Builder::class),
+            $this->createMock(RendererInterface::class),
+            $this->createMock(IoInterface::class),
+            new ArrayConfig([]),
+        );
+        $method = new ReflectionMethod(Generator::class, 'findExistingDtos');
+
+        $dir = sys_get_temp_dir() . '/dto-find-existing-' . uniqid();
+        mkdir($dir . '/src/Dto/Nested', 0777, true);
+        file_put_contents($dir . '/src/Dto/FooDto.php', '<?php');
+        file_put_contents($dir . '/src/Dto/Nested/BarDto.php', '<?php');
+
+        try {
+            $result = $method->invoke($generator, $dir . '/src/Dto');
+            $keys = array_keys($result);
+            sort($keys);
+            $this->assertSame(['Foo', 'Nested/Bar'], $keys);
+            $this->assertArrayHasKey('Nested/Bar', $result);
+        } finally {
+            @unlink($dir . '/src/Dto/FooDto.php');
+            @unlink($dir . '/src/Dto/Nested/BarDto.php');
+            @rmdir($dir . '/src/Dto/Nested');
+            @rmdir($dir . '/src/Dto');
+            @rmdir($dir . '/src');
+            @rmdir($dir);
+        }
+    }
+
+    /**
+     * Mirror regression for `findExistingMappers()` — same forward-slash
+     * hardcode in `#Mapper/(.+)<suffix>Mapper\.php$#`, same fix.
+     *
+     * @return void
+     */
+    public function testFindExistingMappersToleratesEitherDirectorySeparator(): void
+    {
+        $generator = new Generator(
+            $this->createMock(Builder::class),
+            $this->createMock(RendererInterface::class),
+            $this->createMock(IoInterface::class),
+            new ArrayConfig([]),
+        );
+        $method = new ReflectionMethod(Generator::class, 'findExistingMappers');
+
+        $dir = sys_get_temp_dir() . '/dto-find-mappers-' . uniqid();
+        mkdir($dir . '/src/Dto/Mapper/Nested', 0777, true);
+        file_put_contents($dir . '/src/Dto/Mapper/FooDtoMapper.php', '<?php');
+        file_put_contents($dir . '/src/Dto/Mapper/Nested/BarDtoMapper.php', '<?php');
+
+        try {
+            $result = $method->invoke($generator, $dir . '/src/Dto/Mapper');
+            $keys = array_keys($result);
+            sort($keys);
+            $this->assertSame(['Foo', 'Nested/Bar'], $keys);
+            $this->assertArrayHasKey('Nested/Bar', $result);
+        } finally {
+            @unlink($dir . '/src/Dto/Mapper/FooDtoMapper.php');
+            @unlink($dir . '/src/Dto/Mapper/Nested/BarDtoMapper.php');
+            @rmdir($dir . '/src/Dto/Mapper/Nested');
+            @rmdir($dir . '/src/Dto/Mapper');
+            @rmdir($dir . '/src/Dto');
+            @rmdir($dir . '/src');
+            @rmdir($dir);
         }
     }
 }


### PR DESCRIPTION
## Summary

`Generator::findExistingDtos()` and `Generator::findExistingMappers()` both matched on regex patterns with hardcoded forward slashes:

```
#src/Dto/(.+)<suffix>\.php$#
#Mapper/(.+)<suffix>Mapper\.php$#
```

`RecursiveDirectoryIterator` yields paths using the host OS separator, so on Windows where paths come back with backslashes the regex never matched — and the "delete generated DTOs no longer in the spec" pass silently no-op'd, leaving stale files behind on every regenerate.

Replacement pattern accepts either separator via a character class `[/\\]`. Captured nested paths are normalized to forward-slash form so the same nested entry (e.g. `Sub/Foo` on Linux, `Sub\\Foo` on Windows) doesn't land in the result map as two distinct keys depending on host OS.

## How spotted

Surfaced while auditing `dereuromark/cakephp-dto`, which has its own (duplicated) `Generator` carrying the identical bug — already fixed in [dereuromark/cakephp-dto#112](https://github.com/dereuromark/cakephp-dto/pull/112). This PR ports the equivalent fix to the upstream library so other downstream users get it too.

## Tests

Two new regression tests, one each for `findExistingDtos` and `findExistingMappers`. Exercising the Windows path directly on a Linux CI box is awkward, so each test drives the now-DS-tolerant regex via a temp-dir round trip on the host OS path layout (proves the common case still works) plus asserts that nested-directory entries get normalized to the canonical forward-slash form.

phpunit (809/809), phpstan, and phpcs all clean.
