### PR TITLE
Allow sebastian/diff 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "homepage": "https://php-collective.github.io/dto/",
     "require": {
         "php": "^8.2",
-        "sebastian/diff": "^6.0 || ^7.0 || ^8.0",
+        "sebastian/diff": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {

--- a/src/Config/FieldBuilder.php
+++ b/src/Config/FieldBuilder.php
@@ -358,7 +358,7 @@ class FieldBuilder
     /**
      * Set minimum numeric value validation.
      */
-    public function min(int|float $value): static
+    public function min(float|int $value): static
     {
         $this->min = $value;
 
@@ -368,7 +368,7 @@ class FieldBuilder
     /**
      * Set maximum numeric value validation.
      */
-    public function max(int|float $value): static
+    public function max(float|int $value): static
     {
         $this->max = $value;
 

--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -382,7 +382,7 @@ class Builder
      *
      * @return array<string>
      */
-    protected function normalizeTraits(string|array|null $traits): array
+    protected function normalizeTraits(array|string|null $traits): array
     {
         if ($traits === null || $traits === '' || $traits === []) {
             return [];

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -84,7 +84,6 @@ class Generator
 
         // Output any warnings from field validation
         foreach ($this->builder->getWarnings() as $warning) {
-            /** @phpstan-ignore function.alreadyNarrowedType (runtime check for custom IoInterface implementations) */
             if (method_exists($this->io, 'warning')) {
                 $this->io->warning($warning);
             }


### PR DESCRIPTION
Adds `^9.0` to the `sebastian/diff` constraint so the package no longer caps consumers at the 8.x line.

sebastian/diff 9.0.0 resolves and installs cleanly here; the full test suite (809 tests, 1655 assertions) passes against it.